### PR TITLE
chore: sync upstream PR #6526 - feat(cli): inline CSS sourcemaps in addition to JS sourcemaps

### DIFF
--- a/cli/src/tasks/sourcemaps.ts
+++ b/cli/src/tasks/sourcemaps.ts
@@ -12,7 +12,10 @@ function walkDirectory(dirPath: string) {
       walkDirectory(targetFile);
     } else {
       const mapFile = join(dirPath, `${file}.map`);
-      if (extname(file) === '.js' && existsSync(mapFile)) {
+      if (
+        (extname(file) === '.js' || extname(file) === '.css') &&
+        existsSync(mapFile)
+      ) {
         const bufMap = readFileSync(mapFile).toString('base64');
         const bufFile = readFileSync(targetFile, 'utf8');
         const result = bufFile.replace(

--- a/cli/src/tasks/sourcemaps.ts
+++ b/cli/src/tasks/sourcemaps.ts
@@ -12,10 +12,7 @@ function walkDirectory(dirPath: string) {
       walkDirectory(targetFile);
     } else {
       const mapFile = join(dirPath, `${file}.map`);
-      if (
-        (extname(file) === '.js' || extname(file) === '.css') &&
-        existsSync(mapFile)
-      ) {
+      if ((extname(file) === '.js' || extname(file) === '.css') && existsSync(mapFile)) {
         const bufMap = readFileSync(mapFile).toString('base64');
         const bufFile = readFileSync(targetFile, 'utf8');
         const result = bufFile.replace(


### PR DESCRIPTION
## Upstream PR Sync

This PR syncs changes from an external contributor's PR on the official Capacitor repository.

### Original PR
- **PR:** [#6526](https://github.com/ionic-team/capacitor/pull/6526)
- **Title:** feat(cli): inline CSS sourcemaps in addition to JS sourcemaps
- **Author:** @terencehonles

### Automation
- CI will run automatically
- Claude Code will review for security/breaking changes
- If approved, this PR will be auto-merged

---
*Synced from upstream by Capacitor+ Bot*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sourcemaps inlining now supports CSS files. Previously, only JavaScript files with corresponding sourcemap files were inlined; this update extends the functionality to CSS files as well.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->