### PR TITLE
chore: sync upstream PR #7831 - fix(ios): fix URL resolution when external frameworks are loaded

### DIFF
--- a/ios/Capacitor/Capacitor/Router.swift
+++ b/ios/Capacitor/Capacitor/Router.swift
@@ -17,7 +17,7 @@ public struct CapacitorRouter: Router {
     public init() {}
     public var basePath: String = ""
     public func route(for path: String) -> String {
-        let pathUrl = URL(fileURLWithPath: path)
+        let pathUrl = URL(fileURLWithPath: basePath + path)
 
         // If there's no path extension it also means the path is empty or a SPA route
         if pathUrl.pathExtension.isEmpty {


### PR DESCRIPTION
## Upstream PR Sync

This PR syncs changes from an external contributor's PR on the official Capacitor repository.

### Original PR
- **PR:** [#7831](https://github.com/ionic-team/capacitor/pull/7831)
- **Title:** fix(ios): fix URL resolution when external frameworks are loaded
- **Author:** @daniellacosse

### Automation
- CI will run automatically
- Claude Code will review for security/breaking changes
- If approved, this PR will be auto-merged

---
*Synced from upstream by Capacitor+ Bot*