### PR TITLE
chore: sync upstream PR #8155 - Response type correctly mapped on CapacitorHttp plugin call

### DIFF
--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -740,6 +740,7 @@ const initBridge = (w: any): void => {
                   .nativePromise('CapacitorHttp', 'request', {
                     url: this._url,
                     method: this._method,
+                    responseType: this.responseType,
                     data: data !== null ? data : undefined,
                     headers: {
                       ...headers,


### PR DESCRIPTION
## Upstream PR Sync

This PR syncs changes from an external contributor's PR on the official Capacitor repository.

### Original PR
- **PR:** [#8155](https://github.com/ionic-team/capacitor/pull/8155)
- **Title:** Response type correctly mapped on CapacitorHttp plugin call
- **Author:** @cornflakes

### Automation
- CI will run automatically
- Claude Code will review for security/breaking changes
- If approved, this PR will be auto-merged

---
*Synced from upstream by Capacitor+ Bot*