### PR TITLE
chore: sync upstream PR #8249 - fix(ios): remove percent-encoding of cookie values in CapacitorCookies

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/CapacitorCookieManager.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorCookieManager.swift
@@ -46,14 +46,6 @@ public class CapacitorCookieManager {
         return url
     }
 
-    public func encode(_ value: String) -> String {
-        return value.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
-    }
-
-    public func decode(_ value: String) -> String {
-        return value.removingPercentEncoding!
-    }
-
     public func setCookie(_ domain: String, _ action: String) {
         let url = getServerUrl(domain)!
         let jar = HTTPCookieStorage.shared

--- a/ios/Capacitor/Capacitor/Plugins/CapacitorCookies.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorCookies.swift
@@ -31,7 +31,7 @@ public class CAPCookiesPlugin: CAPPlugin, CAPBridgedPlugin {
 
         let expires = call.getString("expires", "")
         let path = call.getString("path", "")
-        cookieManager!.setCookie(url, key, cookieManager!.encode(value), expires, path)
+        cookieManager!.setCookie(url, key, value, expires, path)
         call.resolve()
     }
 


### PR DESCRIPTION
## Upstream PR Sync

This PR syncs changes from an external contributor's PR on the official Capacitor repository.

### Original PR
- **PR:** [#8249](https://github.com/ionic-team/capacitor/pull/8249)
- **Title:** fix(ios): remove percent-encoding of cookie values in CapacitorCookies
- **Author:** @michaelwolz

### Automation
- CI will run automatically
- Claude Code will review for security/breaking changes
- If approved, this PR will be auto-merged

---
*Synced from upstream by Capacitor+ Bot*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified cookie value handling in iOS by removing intermediate encoding/decoding steps. Cookie values are now processed directly without additional transformation layers.

* **Breaking Changes**
  * Removed public helper methods for cookie value encoding and decoding from the iOS plugin API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->