### PR TITLE
fix: SPM correct platform for iOS

### DIFF
--- a/cli/src/ios/common.ts
+++ b/cli/src/ios/common.ts
@@ -113,3 +113,29 @@ export function getMajoriOSVersion(config: Config): string {
   );
   return iosVersion;
 }
+
+export function getMajorMinoriOSVersion(config: Config): string {
+  const pbx = readFileSync(join(config.ios.nativeXcodeProjDirAbs, 'project.pbxproj'), 'utf-8');
+  const searchString = 'IPHONEOS_DEPLOYMENT_TARGET = ';
+  const startIndex = pbx.indexOf(searchString);
+  if (startIndex === -1) {
+    return '';
+  }
+  const valueStart = startIndex + searchString.length;
+  // Extract until semicolon or newline (typical end of value in pbxproj)
+  const endIndex = pbx.indexOf(';', valueStart);
+  const newlineIndex = pbx.indexOf('\n', valueStart);
+  const actualEnd = endIndex !== -1 && newlineIndex !== -1 
+    ? Math.min(endIndex, newlineIndex)
+    : endIndex !== -1 
+      ? endIndex 
+      : newlineIndex !== -1 
+        ? newlineIndex 
+        : pbx.length;
+  let iosVersion = pbx.substring(valueStart, actualEnd).trim();
+  // Remove trailing .0 if present
+  if (iosVersion.endsWith('.0')) {
+    iosVersion = iosVersion.slice(0, -2);
+  }
+  return iosVersion;
+}

--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -8,7 +8,7 @@ import { extract } from 'tar';
 import { getCapacitorPackageVersion } from '../common';
 import type { Config } from '../definitions';
 import { fatal } from '../errors';
-import { getMajoriOSVersion } from '../ios/common';
+import { getMajorMinoriOSVersion } from '../ios/common';
 import { logger } from '../log';
 import type { Plugin } from '../plugin';
 import { getPluginType, PluginType } from '../plugin';
@@ -92,7 +92,7 @@ export async function removeCocoapodsFiles(config: Config): Promise<void> {
 
 export async function generatePackageText(config: Config, plugins: Plugin[]): Promise<string> {
   const iosPlatformVersion = await getCapacitorPackageVersion(config, config.ios.name);
-  const iosVersion = getMajoriOSVersion(config);
+  const iosVersion = getMajorMinoriOSVersion(config);
 
   let packageSwiftText = `// swift-tools-version: 5.9
 import PackageDescription

--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -100,7 +100,7 @@ import PackageDescription
 // DO NOT MODIFY THIS FILE - managed by Capacitor CLI commands
 let package = Package(
     name: "CapApp-SPM",
-    platforms: [.iOS(.v${iosVersion})],
+    platforms: [.iOS(${iosVersion.includes('.') ? `"${iosVersion}"` : `.v${iosVersion}`})],
     products: [
         .library(
             name: "CapApp-SPM",


### PR DESCRIPTION
### The problem

Currently, our [Capacitor updater requires iOS 15.**5** as the minimum iOS deployment target](https://github.com/Cap-go/capacitor-updater/?tab=readme-ov-file#migration-to-v734). Unfortunately, when using SPM, the Capacitor CLI will always default to iOS 15, regardless of whether iOS 15.5 is set in Xcode build settings. This is problematic and causes build issues.

The problem was first reported here: https://discord.com/channels/912707985829163099/1450088141997215744

### Motivation

The Capacitor CLI should work with our own plugin when using SPM. This is a high priority issue as this is currently preventing some users from using Capgo. We must fix it as soon as possible


### Business impact

**HIGH** ❗️

This issue is currently preventing some users from using Capgo, which could negatively impact our MMR. This **MUST** ne resolved as sonn as possible


### Documentation used

https://developer.apple.com/documentation/packagedescription/supportedplatform/ios(_:)-83bbf
I use `.iOS("15.5")` when a dot version is detected, `iOS(.v15)` if no dot version is detected. This is required by Apple

### Testing

I tested manually. If the test app is required, I will provide a zip of it.

### Lint

I did not lint. This project differs from a typical Capgo project and the lint command did not work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS deployment target detection for more robust build configuration parsing.
  * Enhanced Package.swift platform version generation with better format handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->