### PR TITLE
chore: sync upstream PR #8458 - fix(cli): iOS allow provision update on build xArchieve

### DIFF
--- a/cli/src/ios/build.ts
+++ b/cli/src/ios/build.ts
@@ -49,6 +49,8 @@ export async function buildiOS(config: Config, buildOptions: BuildCommandOptions
 
   if (buildOptions.xcodeSigningType == 'manual') {
     buildArgs.push(`PROVISIONING_PROFILE_SPECIFIER=${buildOptions.xcodeProvisioningProfile}`);
+  } else {
+    buildArgs.push('-allowProvisioningUpdates');
   }
 
   await runTask('Building xArchive', async () =>


### PR DESCRIPTION
## Upstream PR Sync

This PR syncs changes from an external contributor's PR on the official Capacitor repository.

### Original PR
- **PR:** [#8458](https://github.com/ionic-team/capacitor/pull/8458)
- **Title:** fix(cli): iOS allow provision update on build xArchieve
- **Author:** @EltonFaust

### Automation
- CI will run automatically
- Claude Code will review for security/breaking changes
- If approved, this PR will be auto-merged
- A new release will be published automatically

---
*Synced from upstream by Capacitor+ Bot*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS app builds to automatically handle provisioning updates during the build process when automatic signing is configured, enhancing build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->