### PR TITLE
chore: sync upstream PR #8463 - fix(cli): mark Cordova CocoaPods plugins as incompatible in SPM

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -44,8 +44,14 @@ export async function updateIOS(config: Config, deployment: boolean): Promise<vo
 }
 
 async function updatePluginFiles(config: Config, plugins: Plugin[], deployment: boolean) {
+  const isSPM = (await config.ios.packageManager) === 'SPM';
   await removePluginsNativeFiles(config);
-  const cordovaPlugins = plugins.filter((p) => getPluginType(p, platform) === PluginType.Cordova);
+  let cordovaPlugins = plugins.filter((p) => getPluginType(p, platform) === PluginType.Cordova);
+  let incompatibleCordovaPlugins = plugins.filter((p) => getPluginType(p, platform) === PluginType.Incompatible);
+  if (isSPM) {
+    incompatibleCordovaPlugins = incompatibleCordovaPlugins.concat(cordovaPlugins.filter((p) => needsSPMDep(p)));
+    cordovaPlugins = cordovaPlugins.filter((p) => !needsSPMDep(p));
+  }
   if (cordovaPlugins.length > 0) {
     await copyPluginsNativeFiles(config, cordovaPlugins);
   }
@@ -54,7 +60,7 @@ async function updatePluginFiles(config: Config, plugins: Plugin[], deployment: 
   }
   await handleCordovaPluginsJS(cordovaPlugins, config, platform);
   await checkPluginDependencies(plugins, platform, config.app.extConfig.cordova?.failOnUninstalledPlugins);
-  if ((await config.ios.packageManager) === 'SPM') {
+  if (isSPM) {
     await generateCordovaPackageFiles(cordovaPlugins, config);
 
     const validSPMPackages = await checkPluginsForPackageSwift(config, plugins);
@@ -66,7 +72,6 @@ async function updatePluginFiles(config: Config, plugins: Plugin[], deployment: 
   }
   await logCordovaManualSteps(cordovaPlugins, config, platform);
 
-  const incompatibleCordovaPlugins = plugins.filter((p) => getPluginType(p, platform) === PluginType.Incompatible);
   printPlugins(incompatibleCordovaPlugins, platform, 'incompatible');
 }
 
@@ -676,4 +681,10 @@ async function replaceFrameworkVariables(config: Config, prefsArray: any[], fram
     );
   });
   return frameworkString;
+}
+
+function needsSPMDep(plugin: Plugin): boolean {
+  const podspecs = getPlatformElement(plugin, 'ios', 'podspec');
+  const platformTag = getPluginPlatform(plugin, platform);
+  return podspecs.length > 0 && !platformTag.$?.package;
 }


### PR DESCRIPTION
## Upstream PR Sync

This PR syncs changes from an external contributor's PR on the official Capacitor repository.

### Original PR
- **PR:** [#8463](https://github.com/ionic-team/capacitor/pull/8463)
- **Title:** fix(cli): mark Cordova CocoaPods plugins as incompatible in SPM
- **Author:** @jcesarmobile

### Automation
- CI will run automatically
- Claude Code will review for security/breaking changes
- If approved, this PR will be auto-merged
- A new release will be published automatically

---
*Synced from upstream by Capacitor+ Bot*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced plugin compatibility detection for iOS development with Swift Package Manager. The system now more accurately identifies compatible plugins and categorizes them appropriately based on package manager configuration, improving build reliability for both SPM and CocoaPods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->