### PR TITLE
chore: sync upstream PR #8524 - fix(ios): remove Cordova.framework from Capacitor project

### DIFF
--- a/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
+++ b/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
@@ -114,13 +114,6 @@
 			remoteGlobalIDString = 50503EDE1FC08594003606DC;
 			remoteInfo = Avocado;
 		};
-		62959B9F2526474300A3D7F1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 62959B9B2526474300A3D7F1 /* CapacitorCordova.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 2F5C86DC1FE94845004B09C7;
-			remoteInfo = Cordova;
-		};
 		6296A796253A2EAE005A202A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 50503ED61FC08594003606DC /* Project object */;
@@ -211,9 +204,7 @@
 		62959B132524DA7700A3D7F1 /* CAPPlugin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CAPPlugin.h; sourceTree = "<group>"; };
 		62959B142524DA7700A3D7F1 /* CAPBridge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CAPBridge.swift; sourceTree = "<group>"; };
 		62959B152524DA7700A3D7F1 /* CAPNotifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CAPNotifications.swift; sourceTree = "<group>"; };
-		62959B56252518FB00A3D7F1 /* Cordova.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Cordova.framework; sourceTree = "<group>"; };
 		62959B8225253A9500A3D7F1 /* Capacitor.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = Capacitor.modulemap; sourceTree = "<group>"; };
-		62959B9B2526474300A3D7F1 /* CapacitorCordova.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CapacitorCordova.xcodeproj; path = ../CapacitorCordova/CapacitorCordova.xcodeproj; sourceTree = "<group>"; };
 		62959BBD2526510200A3D7F1 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6296A77B253A2E49005A202A /* TestsHostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestsHostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6296A77D253A2E49005A202A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -303,8 +294,6 @@
 		501CBAA51FC0A723009B0D4D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				62959B9B2526474300A3D7F1 /* CapacitorCordova.xcodeproj */,
-				62959B56252518FB00A3D7F1 /* Cordova.framework */,
 				501CBAA61FC0A723009B0D4D /* WebKit.framework */,
 			);
 			name = Frameworks;
@@ -432,14 +421,6 @@
 				A38C3D7A2848BE6F004B3680 /* CapacitorCookieManager.swift */,
 			);
 			path = Plugins;
-			sourceTree = "<group>";
-		};
-		62959B9C2526474300A3D7F1 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				62959BA02526474300A3D7F1 /* Cordova.framework */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		6296A77C253A2E49005A202A /* TestsHostApp */ = {
@@ -638,12 +619,6 @@
 			mainGroup = 50503ED51FC08594003606DC;
 			productRefGroup = 50503EE01FC08594003606DC /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 62959B9C2526474300A3D7F1 /* Products */;
-					ProjectRef = 62959B9B2526474300A3D7F1 /* CapacitorCordova.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				50503EDE1FC08594003606DC /* Capacitor */,
@@ -653,16 +628,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		62959BA02526474300A3D7F1 /* Cordova.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Cordova.framework;
-			remoteRef = 62959B9F2526474300A3D7F1 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		50503EDD1FC08594003606DC /* Resources */ = {

--- a/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
+++ b/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
@@ -58,7 +58,6 @@
 		62959B452524DA7800A3D7F1 /* CAPPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 62959B132524DA7700A3D7F1 /* CAPPlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		62959B462524DA7800A3D7F1 /* CAPBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62959B142524DA7700A3D7F1 /* CAPBridge.swift */; };
 		62959B472524DA7800A3D7F1 /* CAPNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62959B152524DA7700A3D7F1 /* CAPNotifications.swift */; };
-		62959BA52526475A00A3D7F1 /* Cordova.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 62959BA02526474300A3D7F1 /* Cordova.framework */; };
 		6296A77E253A2E49005A202A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6296A77D253A2E49005A202A /* AppDelegate.swift */; };
 		6296A782253A2E49005A202A /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6296A781253A2E49005A202A /* ViewController.swift */; };
 		6296A7A0253A2E49005A202A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6296A7A1253A2E49005A202A /* SceneDelegate.swift */; };
@@ -272,7 +271,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				501CBAA71FC0A723009B0D4D /* WebKit.framework in Frameworks */,
-				62959BA52526475A00A3D7F1 /* Cordova.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/CapacitorCordova/CapacitorCordova.xcodeproj/project.pbxproj
+++ b/ios/CapacitorCordova/CapacitorCordova.xcodeproj/project.pbxproj
@@ -38,19 +38,19 @@
 		62959B6A252524D700A3D7F1 /* CDVPluginManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 62959B68252524D700A3D7F1 /* CDVPluginManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		62959B6B252524D700A3D7F1 /* CDVPluginManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 62959B69252524D700A3D7F1 /* CDVPluginManager.m */; };
 		A76739742B98CC7800795F7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A76739732B98CC7800795F7B /* PrivacyInfo.xcprivacy */; };
-		D4DA0E972FFD28680031AA74 /* Capacitor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4DA0E962FFD28680031AA74 /* Capacitor.framework */; };
-		D4DA0E982FFD28680031AA74 /* Capacitor.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D4DA0E962FFD28680031AA74 /* Capacitor.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D4DA0E9B2FFD28C60031AA74 /* Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DA0E9A2FFD28C60031AA74 /* Plugin.swift */; };
+		D4DA0ED52FFD573E0031AA74 /* Capacitor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4DA0ED42FFD573E0031AA74 /* Capacitor.framework */; };
+		D4DA0ED62FFD573E0031AA74 /* Capacitor.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D4DA0ED42FFD573E0031AA74 /* Capacitor.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		D4DA0E992FFD28680031AA74 /* Embed Frameworks */ = {
+		D4DA0ED72FFD573E0031AA74 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				D4DA0E982FFD28680031AA74 /* Capacitor.framework in Embed Frameworks */,
+				D4DA0ED62FFD573E0031AA74 /* Capacitor.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -94,6 +94,7 @@
 		A76739732B98CC7800795F7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D4DA0E962FFD28680031AA74 /* Capacitor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Capacitor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4DA0E9A2FFD28C60031AA74 /* Plugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plugin.swift; sourceTree = "<group>"; };
+		D4DA0ED42FFD573E0031AA74 /* Capacitor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Capacitor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -101,7 +102,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D4DA0E972FFD28680031AA74 /* Capacitor.framework in Frameworks */,
+				D4DA0ED52FFD573E0031AA74 /* Capacitor.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -185,6 +186,7 @@
 		D4DA0E952FFD28680031AA74 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D4DA0ED42FFD573E0031AA74 /* Capacitor.framework */,
 				D4DA0E962FFD28680031AA74 /* Capacitor.framework */,
 			);
 			name = Frameworks;
@@ -229,7 +231,7 @@
 				2F5C86D81FE94845004B09C7 /* Frameworks */,
 				2F5C86D91FE94845004B09C7 /* Headers */,
 				2F5C86DA1FE94845004B09C7 /* Resources */,
-				D4DA0E992FFD28680031AA74 /* Embed Frameworks */,
+				D4DA0ED72FFD573E0031AA74 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/ios/CapacitorCordova/CapacitorCordova.xcodeproj/project.pbxproj
+++ b/ios/CapacitorCordova/CapacitorCordova.xcodeproj/project.pbxproj
@@ -38,7 +38,24 @@
 		62959B6A252524D700A3D7F1 /* CDVPluginManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 62959B68252524D700A3D7F1 /* CDVPluginManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		62959B6B252524D700A3D7F1 /* CDVPluginManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 62959B69252524D700A3D7F1 /* CDVPluginManager.m */; };
 		A76739742B98CC7800795F7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A76739732B98CC7800795F7B /* PrivacyInfo.xcprivacy */; };
+		D4DA0E972FFD28680031AA74 /* Capacitor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4DA0E962FFD28680031AA74 /* Capacitor.framework */; };
+		D4DA0E982FFD28680031AA74 /* Capacitor.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D4DA0E962FFD28680031AA74 /* Capacitor.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D4DA0E9B2FFD28C60031AA74 /* Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DA0E9A2FFD28C60031AA74 /* Plugin.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		D4DA0E992FFD28680031AA74 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				D4DA0E982FFD28680031AA74 /* Capacitor.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		0B61A7E32B114A9F0035F2DB /* CDVWebViewProcessPoolFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVWebViewProcessPoolFactory.m; sourceTree = "<group>"; };
@@ -75,6 +92,8 @@
 		62959B68252524D700A3D7F1 /* CDVPluginManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDVPluginManager.h; sourceTree = "<group>"; };
 		62959B69252524D700A3D7F1 /* CDVPluginManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVPluginManager.m; sourceTree = "<group>"; };
 		A76739732B98CC7800795F7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		D4DA0E962FFD28680031AA74 /* Capacitor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Capacitor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D4DA0E9A2FFD28C60031AA74 /* Plugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plugin.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +101,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D4DA0E972FFD28680031AA74 /* Capacitor.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,6 +112,7 @@
 			isa = PBXGroup;
 			children = (
 				2F5C86DE1FE94845004B09C7 /* CapacitorCordova */,
+				D4DA0E952FFD28680031AA74 /* Frameworks */,
 				2F5C86DD1FE94845004B09C7 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -127,6 +148,7 @@
 		2F5C86E81FE94861004B09C7 /* Public */ = {
 			isa = PBXGroup;
 			children = (
+				D4DA0E9A2FFD28C60031AA74 /* Plugin.swift */,
 				2FE19E2820473160002A4E89 /* AppDelegate.h */,
 				2FE19E2920473160002A4E89 /* AppDelegate.m */,
 				2F5C87131FE98417004B09C7 /* CDV.h */,
@@ -158,6 +180,14 @@
 				0B61A7E32B114A9F0035F2DB /* CDVWebViewProcessPoolFactory.m */,
 			);
 			path = Public;
+			sourceTree = "<group>";
+		};
+		D4DA0E952FFD28680031AA74 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				D4DA0E962FFD28680031AA74 /* Capacitor.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -199,6 +229,7 @@
 				2F5C86D81FE94845004B09C7 /* Frameworks */,
 				2F5C86D91FE94845004B09C7 /* Headers */,
 				2F5C86DA1FE94845004B09C7 /* Resources */,
+				D4DA0E992FFD28680031AA74 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -220,6 +251,7 @@
 				TargetAttributes = {
 					2F5C86DB1FE94845004B09C7 = {
 						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 2650;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -268,6 +300,7 @@
 				2FAD9773203C77B9000D30F8 /* CDVConfigParser.m in Sources */,
 				2F856C00203DEB320047344A /* CDVViewController.m in Sources */,
 				2F5C87201FE98418004B09C7 /* CDVInvokedUrlCommand.m in Sources */,
+				D4DA0E9B2FFD28C60031AA74 /* Plugin.swift in Sources */,
 				2FE19E2B20473160002A4E89 /* AppDelegate.m in Sources */,
 				2F8AC283217F3A20008C2C33 /* CDVURLProtocol.m in Sources */,
 			);
@@ -395,6 +428,7 @@
 		2F5C86E51FE94845004B09C7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -408,6 +442,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.getcapacitor.ios.CapacitorCordova;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -415,6 +451,7 @@
 		2F5C86E61FE94845004B09C7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -428,6 +465,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.getcapacitor.ios.CapacitorCordova;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/ios/package.json
+++ b/ios/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "verify": "npm run xc:build:Capacitor && npm run xc:build:CapacitorCordova",
     "xc:build:Capacitor": "cd Capacitor && xcodebuild clean test -workspace Capacitor.xcworkspace -scheme Capacitor -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' && cd ..",
-    "xc:build:CapacitorCordova": "cd CapacitorCordova && xcodebuild && cd .."
+    "xc:build:CapacitorCordova": "cd Capacitor && xcodebuild clean build -workspace Capacitor.xcworkspace -scheme Cordova && cd .."
   },
   "peerDependencies": {
     "@capacitor-plus/core": "^8.5.0",


### PR DESCRIPTION
## Merge Conflict Resolution Required

The sync of upstream PR #8524 from @jcesarmobile encountered merge conflicts.

**Original PR:** https://github.com/ionic-team/capacitor/pull/8524

### What happened
- Claude Code attempted to resolve the merge conflicts
- This PR was created so CI and manual review can finish the sync safely

---
*Synced from upstream by Capacitor+ Bot*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading a custom URL in the app during `run`.
  * Added broader Cordova plugin support on Android and iOS, including new bridge handling and package generation improvements.
  * Added a new API for reading double values from plugin configuration.

* **Bug Fixes**
  * Improved system bar behavior and safe-area handling.
  * Fixed long-running CI jobs by increasing workflow timeouts.

* **Chores**
  * Updated Android, iOS, CLI, and core packages to the latest alpha release and refreshed changelogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->