### PR TITLE
chore: sync upstream PR #8527 - fix(ios): adopt UIScene life cycle in default iOS app templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   setup:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - name: Get Latest
         uses: actions/setup-node@v6
@@ -32,7 +32,7 @@ jobs:
           key: ${{ runner.OS }}-dependencies-cache-${{ hashFiles('**/package.json') }}
   lint:
     runs-on: macos-15
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -48,7 +48,7 @@ jobs:
       - run: npm run lint
   test-cli:
     runs-on: macos-15
-    timeout-minutes: 60
+    timeout-minutes: 30
     needs:
       - setup
       - lint
@@ -69,7 +69,7 @@ jobs:
         working-directory: ./cli
   test-core:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     needs:
       - setup
       - lint
@@ -90,7 +90,7 @@ jobs:
         working-directory: ./core
   test-ios:
     runs-on: macos-15
-    timeout-minutes: 60
+    timeout-minutes: 30
     needs:
       - setup
       - lint
@@ -118,7 +118,7 @@ jobs:
         run: sh ./scripts/native-podspec.sh lint
   test-android:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     needs:
       - setup
       - lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.3](https://github.com/ionic-team/capacitor/compare/8.3.2...8.3.3) (2026-05-08)
+
+### Bug Fixes
+
+- **cli:** copy plugin files in CocoaPods projects ([#8467](https://github.com/ionic-team/capacitor/issues/8467)) ([b2d7719](https://github.com/ionic-team/capacitor/commit/b2d771926a180e60deea31992d7d4abcd5ca3bc7))
+
 ## [8.3.2](https://github.com/ionic-team/capacitor/compare/8.3.1...8.3.2) (2026-05-07)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.4](https://github.com/ionic-team/capacitor/compare/8.3.3...8.3.4) (2026-05-12)
+
+**Note:** Version bump only for package capacitor
+
 ## [8.3.3](https://github.com/ionic-team/capacitor/compare/8.3.2...8.3.3) (2026-05-08)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.2](https://github.com/ionic-team/capacitor/compare/8.3.1...8.3.2) (2026-05-07)
+
+### Bug Fixes
+
+- **cli:** add cSettings support for compiler flags in generated Package.swift ([#8448](https://github.com/ionic-team/capacitor/issues/8448)) ([0bd0676](https://github.com/ionic-team/capacitor/commit/0bd0676315c5fd77e50312dd7b5bf4990dcbd7d0))
+- **cli:** add system framework and weak framework support in SPM Package.swift ([#8447](https://github.com/ionic-team/capacitor/issues/8447)) ([3232f0f](https://github.com/ionic-team/capacitor/commit/3232f0fe1d9811b0b5c500e3dc05cb8a250177f8))
+- **cli:** correct Capacitor plugin SPM compat check ([#8440](https://github.com/ionic-team/capacitor/issues/8440)) ([e5ccc45](https://github.com/ionic-team/capacitor/commit/e5ccc451dda27d56bca824ed644bd20fe4d988cb))
+- **cli:** generate binaryTarget entries for custom xcframeworks in Package.swift ([#8445](https://github.com/ionic-team/capacitor/issues/8445)) ([1f7e33f](https://github.com/ionic-team/capacitor/commit/1f7e33fca43d183332ec19d22b0d75ef81d8cc6d))
+- **cli:** generate resource entries in Package.swift ([#8455](https://github.com/ionic-team/capacitor/issues/8455)) ([790bd27](https://github.com/ionic-team/capacitor/commit/790bd27123497111984227010c3162cec94a108e))
+- **cli:** handle Cordova plugins without iOS source files ([#8443](https://github.com/ionic-team/capacitor/issues/8443)) ([0da130e](https://github.com/ionic-team/capacitor/commit/0da130eb7a861bee4e2c35bc0aac53ba9c983fc3))
+- **cli:** link plugin dependencies in Package.swift ([#8457](https://github.com/ionic-team/capacitor/issues/8457)) ([b3c769e](https://github.com/ionic-team/capacitor/commit/b3c769e856c826b1174518877cf86ac7ce73bf09))
+- **ios:** support Cordova plugins with Package.swift ([#8438](https://github.com/ionic-team/capacitor/issues/8438)) ([139943b](https://github.com/ionic-team/capacitor/commit/139943b0c05fddb2d1ce2d6f468800fddf17b4cf))
+- **SystemBars:** avoid extra view padding on API <= 34 ([#8439](https://github.com/ionic-team/capacitor/issues/8439)) ([5b135a7](https://github.com/ionic-team/capacitor/commit/5b135a70217be560e7176c8d5b514cc92ed3e4e4))
+
 ## [8.3.1](https://github.com/ionic-team/capacitor/compare/8.3.0...8.3.1) (2026-04-16)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.4.1](https://github.com/ionic-team/capacitor/compare/8.4.0...8.4.1) (2026-06-19)
+
+### Bug Fixes
+
+- **cli:** make SPM dependency patch work on prereleases ([#8508](https://github.com/ionic-team/capacitor/issues/8508)) ([6048e90](https://github.com/ionic-team/capacitor/commit/6048e90171afa0229a3c25b52a23c377c6bb804c))
+- **cli:** patch Capacitor SPM dependency version in plugins ([#8492](https://github.com/ionic-team/capacitor/issues/8492)) ([28bb2c6](https://github.com/ionic-team/capacitor/commit/28bb2c687069dfdd6aa7abc866004a1c6388d103))
+
 # [8.4.0](https://github.com/ionic-team/capacitor/compare/8.3.4...8.4.0) (2026-06-02)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.4.0](https://github.com/ionic-team/capacitor/compare/8.3.4...8.4.0) (2026-06-02)
+
+### Bug Fixes
+
+- **android:** show only the requested system bar ([#8480](https://github.com/ionic-team/capacitor/issues/8480)) ([4c6c321](https://github.com/ionic-team/capacitor/commit/4c6c3219afb5223211e857457e46283c37eb9424))
+- **cli:** revert live reload config on failure ([#8485](https://github.com/ionic-team/capacitor/issues/8485)) ([1d031a4](https://github.com/ionic-team/capacitor/commit/1d031a4abec2c793079ba8897ad2e40c4cc6c7f9))
+- **SystemBars:** make `safe-area-inset-x` available on API <= 34 ([#8424](https://github.com/ionic-team/capacitor/issues/8424)) ([e456de0](https://github.com/ionic-team/capacitor/commit/e456de083e19644f484bec5a5359cb67960ac8bc))
+- **SystemBars:** respect `insetsHandling` disable ([#8481](https://github.com/ionic-team/capacitor/issues/8481)) ([d4ad7ff](https://github.com/ionic-team/capacitor/commit/d4ad7ffe39daf66e0cfc63af9028d5c05543bde7))
+
+### Features
+
+- add method getDouble to plugin config ([#7638](https://github.com/ionic-team/capacitor/issues/7638)) ([93c72de](https://github.com/ionic-team/capacitor/commit/93c72de40a2ec4c78b33659250cb08340083088e))
+- **cli:** add experimental packageOptions ([#8471](https://github.com/ionic-team/capacitor/issues/8471)) ([258867b](https://github.com/ionic-team/capacitor/commit/258867b7bf37b1837b99b02ec9638e5a6df08d97))
+- **cli:** capture ios_package_manager in telemetry ([#8482](https://github.com/ionic-team/capacitor/issues/8482)) ([b4b297a](https://github.com/ionic-team/capacitor/commit/b4b297a52f8732659662d5e5aaeff81c0f7d9835))
+
 ## [8.3.4](https://github.com/ionic-team/capacitor/compare/8.3.3...8.3.4) (2026-05-12)
 
 **Note:** Version bump only for package capacitor

--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.3](https://github.com/ionic-team/capacitor/compare/8.3.2...8.3.3) (2026-05-08)
+
+**Note:** Version bump only for package @capacitor/android
+
 ## [8.3.2](https://github.com/ionic-team/capacitor/compare/8.3.1...8.3.2) (2026-05-07)
 
 ### Bug Fixes

--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.2](https://github.com/ionic-team/capacitor/compare/8.3.1...8.3.2) (2026-05-07)
+
+### Bug Fixes
+
+- **SystemBars:** avoid extra view padding on API <= 34 ([#8439](https://github.com/ionic-team/capacitor/issues/8439)) ([5b135a7](https://github.com/ionic-team/capacitor/commit/5b135a70217be560e7176c8d5b514cc92ed3e4e4))
+
 ## [8.3.1](https://github.com/ionic-team/capacitor/compare/8.3.0...8.3.1) (2026-04-16)
 
 ### Bug Fixes

--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.4](https://github.com/ionic-team/capacitor/compare/8.3.3...8.3.4) (2026-05-12)
+
+**Note:** Version bump only for package @capacitor/android
+
 ## [8.3.3](https://github.com/ionic-team/capacitor/compare/8.3.2...8.3.3) (2026-05-08)
 
 **Note:** Version bump only for package @capacitor/android

--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.4.1](https://github.com/ionic-team/capacitor/compare/8.4.0...8.4.1) (2026-06-19)
+
+**Note:** Version bump only for package @capacitor/android
+
 # [8.4.0](https://github.com/ionic-team/capacitor/compare/8.3.4...8.4.0) (2026-06-02)
 
 ### Bug Fixes

--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.4.0](https://github.com/ionic-team/capacitor/compare/8.3.4...8.4.0) (2026-06-02)
+
+### Bug Fixes
+
+- **android:** show only the requested system bar ([#8480](https://github.com/ionic-team/capacitor/issues/8480)) ([4c6c321](https://github.com/ionic-team/capacitor/commit/4c6c3219afb5223211e857457e46283c37eb9424))
+- **SystemBars:** make `safe-area-inset-x` available on API <= 34 ([#8424](https://github.com/ionic-team/capacitor/issues/8424)) ([e456de0](https://github.com/ionic-team/capacitor/commit/e456de083e19644f484bec5a5359cb67960ac8bc))
+- **SystemBars:** respect `insetsHandling` disable ([#8481](https://github.com/ionic-team/capacitor/issues/8481)) ([d4ad7ff](https://github.com/ionic-team/capacitor/commit/d4ad7ffe39daf66e0cfc63af9028d5c05543bde7))
+
+### Features
+
+- add method getDouble to plugin config ([#7638](https://github.com/ionic-team/capacitor/issues/7638)) ([93c72de](https://github.com/ionic-team/capacitor/commit/93c72de40a2ec4c78b33659250cb08340083088e))
+
 ## [8.3.4](https://github.com/ionic-team/capacitor/compare/8.3.3...8.3.4) (2026-05-12)
 
 **Note:** Version bump only for package @capacitor/android

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -246,14 +246,14 @@ public class BridgeWebChromeClient extends WebChromeClient {
     public void onGeolocationPermissionsShowPrompt(String origin, GeolocationPermissions.Callback callback) {
         super.onGeolocationPermissionsShowPrompt(origin, callback);
         Logger.debug("onGeolocationPermissionsShowPrompt: DOING IT HERE FOR ORIGIN: " + origin);
-        final String[] geoPermissions = {Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION};
+        final String[] geoPermissions = { Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION };
 
         if (!PermissionHelper.hasPermissions(bridge.getContext(), geoPermissions)) {
             permissionListener = (isGranted) -> {
                 if (isGranted) {
                     callback.invoke(origin, true, false);
                 } else {
-                    final String[] coarsePermission = {Manifest.permission.ACCESS_COARSE_LOCATION};
+                    final String[] coarsePermission = { Manifest.permission.ACCESS_COARSE_LOCATION };
                     if (
                         Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
                         PermissionHelper.hasPermissions(bridge.getContext(), coarsePermission)
@@ -294,7 +294,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
                         filePathCallback.onReceiveValue(null);
                     }
                 };
-                final String[] camPermission = {Manifest.permission.CAMERA};
+                final String[] camPermission = { Manifest.permission.CAMERA };
                 permissionLauncher.launch(camPermission);
             }
         } else {
@@ -305,7 +305,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
     }
 
     private boolean isMediaCaptureSupported() {
-        String[] permissions = {Manifest.permission.CAMERA};
+        String[] permissions = { Manifest.permission.CAMERA };
         return (
             PermissionHelper.hasPermissions(bridge.getContext(), permissions) ||
             !PermissionHelper.hasDefinedPermission(bridge.getContext(), Manifest.permission.CAMERA)
@@ -343,7 +343,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
         activityListener = (activityResult) -> {
             Uri[] result = null;
             if (activityResult.getResultCode() == Activity.RESULT_OK) {
-                result = new Uri[] {imageFileUri};
+                result = new Uri[] { imageFileUri };
             }
             filePathCallback.onReceiveValue(result);
         };
@@ -362,7 +362,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
         activityListener = (activityResult) -> {
             Uri[] result = null;
             if (activityResult.getResultCode() == Activity.RESULT_OK) {
-                result = new Uri[] {activityResult.getData().getData()};
+                result = new Uri[] { activityResult.getData().getData() };
             }
             filePathCallback.onReceiveValue(result);
         };

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -340,6 +340,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
             return false;
         }
         takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, imageFileUri);
+        takePictureIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
         activityListener = (activityResult) -> {
             Uri[] result = null;
             if (activityResult.getResultCode() == Activity.RESULT_OK) {

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -282,7 +282,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
         boolean captureEnabled = fileChooserParams.isCaptureEnabled();
         boolean capturePhoto = captureEnabled && acceptTypes.contains("image/*");
         final boolean captureVideo = captureEnabled && acceptTypes.contains("video/*");
-        if ((capturePhoto || captureVideo)) {
+        if (capturePhoto || captureVideo) {
             if (isMediaCaptureSupported()) {
                 showMediaCaptureOrFilePicker(filePathCallback, fileChooserParams, captureVideo);
             } else {
@@ -447,7 +447,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
     }
 
     public boolean isValidMsg(String msg) {
-        return !(msg.contains("%cresult %c") || (msg.contains("%cnative %c")) || msg.equalsIgnoreCase("console.groupEnd"));
+        return !(msg.contains("%cresult %c") || msg.contains("%cnative %c") || msg.equalsIgnoreCase("console.groupEnd"));
     }
 
     private Uri createImageFileUri() throws IOException {

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -246,14 +246,14 @@ public class BridgeWebChromeClient extends WebChromeClient {
     public void onGeolocationPermissionsShowPrompt(String origin, GeolocationPermissions.Callback callback) {
         super.onGeolocationPermissionsShowPrompt(origin, callback);
         Logger.debug("onGeolocationPermissionsShowPrompt: DOING IT HERE FOR ORIGIN: " + origin);
-        final String[] geoPermissions = { Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION };
+        final String[] geoPermissions = {Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION};
 
         if (!PermissionHelper.hasPermissions(bridge.getContext(), geoPermissions)) {
             permissionListener = (isGranted) -> {
                 if (isGranted) {
                     callback.invoke(origin, true, false);
                 } else {
-                    final String[] coarsePermission = { Manifest.permission.ACCESS_COARSE_LOCATION };
+                    final String[] coarsePermission = {Manifest.permission.ACCESS_COARSE_LOCATION};
                     if (
                         Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
                         PermissionHelper.hasPermissions(bridge.getContext(), coarsePermission)
@@ -294,7 +294,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
                         filePathCallback.onReceiveValue(null);
                     }
                 };
-                final String[] camPermission = { Manifest.permission.CAMERA };
+                final String[] camPermission = {Manifest.permission.CAMERA};
                 permissionLauncher.launch(camPermission);
             }
         } else {
@@ -305,7 +305,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
     }
 
     private boolean isMediaCaptureSupported() {
-        String[] permissions = { Manifest.permission.CAMERA };
+        String[] permissions = {Manifest.permission.CAMERA};
         return (
             PermissionHelper.hasPermissions(bridge.getContext(), permissions) ||
             !PermissionHelper.hasDefinedPermission(bridge.getContext(), Manifest.permission.CAMERA)
@@ -343,7 +343,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
         activityListener = (activityResult) -> {
             Uri[] result = null;
             if (activityResult.getResultCode() == Activity.RESULT_OK) {
-                result = new Uri[] { imageFileUri };
+                result = new Uri[] {imageFileUri};
             }
             filePathCallback.onReceiveValue(result);
         };
@@ -362,7 +362,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
         activityListener = (activityResult) -> {
             Uri[] result = null;
             if (activityResult.getResultCode() == Activity.RESULT_OK) {
-                result = new Uri[] { activityResult.getData().getData() };
+                result = new Uri[] {activityResult.getData().getData()};
             }
             filePathCallback.onReceiveValue(result);
         };

--- a/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
@@ -218,7 +218,7 @@ public class FileUtils {
         Cursor cursor = context.getContentResolver().query(uri, null, null, null, null);
         int nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
         cursor.moveToFirst();
-        String name = (cursor.getString(nameIndex));
+        String name = cursor.getString(nameIndex);
         String fileName = sanitizeFilename(name);
         File file = new File(context.getFilesDir(), fileName);
         try {

--- a/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
@@ -118,7 +118,7 @@ public class FileUtils {
                 }
 
                 final String selection = "_id=?";
-                final String[] selectionArgs = new String[] { split[1] };
+                final String[] selectionArgs = new String[] {split[1]};
 
                 return getDataColumn(context, contentUri, selection, selectionArgs);
             }
@@ -195,7 +195,7 @@ public class FileUtils {
         String path = null;
         Cursor cursor = null;
         final String column = "_data";
-        final String[] projection = { column };
+        final String[] projection = {column};
 
         try {
             cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs, null);
@@ -292,7 +292,7 @@ public class FileUtils {
     }
 
     private static String sanitizeFilename(String displayName) {
-        String[] badCharacters = new String[] { "..", "/" };
+        String[] badCharacters = new String[] {"..", "/"};
         String[] segments = displayName.split("/");
         String fileName = segments[segments.length - 1];
         for (String suspString : badCharacters) {

--- a/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
@@ -118,7 +118,7 @@ public class FileUtils {
                 }
 
                 final String selection = "_id=?";
-                final String[] selectionArgs = new String[] {split[1]};
+                final String[] selectionArgs = new String[] { split[1] };
 
                 return getDataColumn(context, contentUri, selection, selectionArgs);
             }
@@ -195,7 +195,7 @@ public class FileUtils {
         String path = null;
         Cursor cursor = null;
         final String column = "_data";
-        final String[] projection = {column};
+        final String[] projection = { column };
 
         try {
             cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs, null);
@@ -292,7 +292,7 @@ public class FileUtils {
     }
 
     private static String sanitizeFilename(String displayName) {
-        String[] badCharacters = new String[] {"..", "/"};
+        String[] badCharacters = new String[] { "..", "/" };
         String[] segments = displayName.split("/");
         String fileName = segments[segments.length - 1];
         for (String suspString : badCharacters) {

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -465,7 +465,7 @@ public class Plugin {
      * @param callbackName the name of the callback to run when the permission request is complete
      */
     protected void requestPermissionForAlias(@NonNull String alias, @NonNull PluginCall call, @NonNull String callbackName) {
-        requestPermissionForAliases(new String[] { alias }, call, callbackName);
+        requestPermissionForAliases(new String[] {alias}, call, callbackName);
     }
 
     /**
@@ -583,7 +583,7 @@ public class Plugin {
      */
     @Deprecated
     public void pluginRequestPermission(String permission, int requestCode) {
-        ActivityCompat.requestPermissions(getActivity(), new String[] { permission }, requestCode);
+        ActivityCompat.requestPermissions(getActivity(), new String[] {permission}, requestCode);
     }
 
     /**

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -465,7 +465,7 @@ public class Plugin {
      * @param callbackName the name of the callback to run when the permission request is complete
      */
     protected void requestPermissionForAlias(@NonNull String alias, @NonNull PluginCall call, @NonNull String callbackName) {
-        requestPermissionForAliases(new String[] {alias}, call, callbackName);
+        requestPermissionForAliases(new String[] { alias }, call, callbackName);
     }
 
     /**
@@ -583,7 +583,7 @@ public class Plugin {
      */
     @Deprecated
     public void pluginRequestPermission(String permission, int requestCode) {
-        ActivityCompat.requestPermissions(getActivity(), new String[] {permission}, requestCode);
+        ActivityCompat.requestPermissions(getActivity(), new String[] { permission }, requestCode);
     }
 
     /**

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginConfig.java
@@ -66,6 +66,17 @@ public class PluginConfig {
     }
 
     /**
+     * Get a double value for a plugin in the Capacitor config.
+     *
+     * @param configKey The key of the value to retrieve
+     * @param defaultValue A default value to return if the key does not exist in the config
+     * @return The value from the config, if key exists. Default value returned if not
+     */
+    public double getDouble(String configKey, double defaultValue) {
+        return JSONUtils.getDouble(config, configKey, defaultValue);
+    }
+
+    /**
      * Get a string array value for a plugin in the Capacitor config.
      *
      * @param configKey The key of the value to retrieve

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -221,7 +221,7 @@ public class WebViewLocalServer {
     }
 
     private boolean isMainUrl(Uri loadingUrl) {
-        return (bridge.getServerUrl() == null && loadingUrl.getHost().equalsIgnoreCase(bridge.getHost()));
+        return bridge.getServerUrl() == null && loadingUrl.getHost().equalsIgnoreCase(bridge.getHost());
     }
 
     private boolean isAllowedUrl(Uri loadingUrl) {
@@ -722,31 +722,31 @@ public class WebViewLocalServer {
         @Override
         public int available() throws IOException {
             InputStream is = getInputStream();
-            return (is != null) ? is.available() : -1;
+            return is != null ? is.available() : -1;
         }
 
         @Override
         public int read() throws IOException {
             InputStream is = getInputStream();
-            return (is != null) ? is.read() : -1;
+            return is != null ? is.read() : -1;
         }
 
         @Override
         public int read(byte[] b) throws IOException {
             InputStream is = getInputStream();
-            return (is != null) ? is.read(b) : -1;
+            return is != null ? is.read(b) : -1;
         }
 
         @Override
         public int read(byte[] b, int off, int len) throws IOException {
             InputStream is = getInputStream();
-            return (is != null) ? is.read(b, off, len) : -1;
+            return is != null ? is.read(b, off, len) : -1;
         }
 
         @Override
         public long skip(long n) throws IOException {
             InputStream is = getInputStream();
-            return (is != null) ? is.skip(n) : 0;
+            return is != null ? is.skip(n) : 0;
         }
     }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaWebViewImpl.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaWebViewImpl.java
@@ -70,14 +70,12 @@ public class MockCordovaWebViewImpl implements CordovaWebView {
 
         @Override
         public void onNativeToJsMessageAvailable(final NativeToJsMessageQueue queue) {
-            cordova
-                .getActivity()
-                .runOnUiThread(() -> {
-                    String js = queue.popAndEncodeAsJs();
-                    if (js != null) {
-                        webView.evaluateJavascript(js, null);
-                    }
-                });
+            cordova.getActivity().runOnUiThread(() -> {
+                String js = queue.popAndEncodeAsJs();
+                if (js != null) {
+                    webView.evaluateJavascript(js, null);
+                }
+            });
         }
     }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorCookieManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorCookieManager.java
@@ -192,12 +192,12 @@ public class CapacitorCookieManager extends CookieManager {
     @Override
     public void put(URI uri, Map<String, List<String>> responseHeaders) {
         // make sure our args are valid
-        if ((uri == null) || (responseHeaders == null)) return;
+        if (uri == null || responseHeaders == null) return;
 
         // go over the headers
         for (String headerKey : responseHeaders.keySet()) {
             // ignore headers which aren't cookie related
-            if ((headerKey == null) || !(headerKey.equalsIgnoreCase("Set-Cookie2") || headerKey.equalsIgnoreCase("Set-Cookie"))) continue;
+            if (headerKey == null || !(headerKey.equalsIgnoreCase("Set-Cookie2") || headerKey.equalsIgnoreCase("Set-Cookie"))) continue;
 
             // process each of the headers
             for (String headerValue : Objects.requireNonNull(responseHeaders.get(headerKey))) {
@@ -215,7 +215,7 @@ public class CapacitorCookieManager extends CookieManager {
     @Override
     public Map<String, List<String>> get(URI uri, Map<String, List<String>> requestHeaders) {
         // make sure our args are valid
-        if ((uri == null) || (requestHeaders == null)) throw new IllegalArgumentException("Argument is null");
+        if (uri == null || requestHeaders == null) throw new IllegalArgumentException("Argument is null");
 
         // save our url once
         String url = uri.toString();

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorHttp.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorHttp.java
@@ -18,8 +18,8 @@ import java.util.concurrent.Executors;
 
 @CapacitorPlugin(
     permissions = {
-        @Permission(strings = { Manifest.permission.WRITE_EXTERNAL_STORAGE }, alias = "HttpWrite"),
-        @Permission(strings = { Manifest.permission.READ_EXTERNAL_STORAGE }, alias = "HttpRead")
+        @Permission(strings = {Manifest.permission.WRITE_EXTERNAL_STORAGE}, alias = "HttpWrite"),
+        @Permission(strings = {Manifest.permission.READ_EXTERNAL_STORAGE}, alias = "HttpRead")
     }
 )
 public class CapacitorHttp extends Plugin {

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorHttp.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorHttp.java
@@ -18,8 +18,8 @@ import java.util.concurrent.Executors;
 
 @CapacitorPlugin(
     permissions = {
-        @Permission(strings = {Manifest.permission.WRITE_EXTERNAL_STORAGE}, alias = "HttpWrite"),
-        @Permission(strings = {Manifest.permission.READ_EXTERNAL_STORAGE}, alias = "HttpRead")
+        @Permission(strings = { Manifest.permission.WRITE_EXTERNAL_STORAGE }, alias = "HttpWrite"),
+        @Permission(strings = { Manifest.permission.READ_EXTERNAL_STORAGE }, alias = "HttpRead")
     }
 )
 public class CapacitorHttp extends Plugin {

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -164,13 +164,18 @@ public class SystemBars extends Plugin {
     }
 
     private void initSafeAreaCSSVariables() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && insetHandlingEnabled) {
+        WindowInsetsCompat insets;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
             View v = (View) this.getBridge().getWebView().getParent();
-            WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(v);
-            if (insets != null) {
-                Insets safeAreaInsets = calcSafeAreaInsets(insets);
-                injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
-            }
+            insets = ViewCompat.getRootWindowInsets(v);
+        } else {
+            insets = WindowInsetsCompat.CONSUMED;
+        }
+
+        if (insets != null) {
+            Insets safeAreaInsets = calcSafeAreaInsets(insets);
+            injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
         }
     }
 
@@ -186,10 +191,8 @@ public class SystemBars extends Plugin {
                 // We need to correct for a possible shown IME
                 v.setPadding(0, 0, 0, keyboardVisible ? imeInsets.bottom : 0);
 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && hasViewportCover && insetHandlingEnabled) {
-                    Insets safeAreaInsets = calcSafeAreaInsets(insets);
-                    injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
-                }
+                Insets safeAreaInsets = calcSafeAreaInsets(insets);
+                injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
 
                 return new WindowInsetsCompat.Builder(insets)
                     .setInsets(
@@ -221,10 +224,8 @@ public class SystemBars extends Plugin {
                 .setInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(), Insets.of(0, 0, 0, 0))
                 .build();
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && hasViewportCover && insetHandlingEnabled) {
-                Insets safeAreaInsets = calcSafeAreaInsets(newInsets);
-                injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
-            }
+            Insets safeAreaInsets = calcSafeAreaInsets(newInsets);
+            injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
 
             return newInsets;
         });

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -16,6 +16,7 @@ import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.webkit.WebViewCompat;
+import com.getcapacitor.Logger;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -32,6 +33,7 @@ public class SystemBars extends Plugin {
     static final String BAR_STATUS_BAR = "StatusBar";
     static final String BAR_GESTURE_BAR = "NavigationBar";
 
+    // TODO: In Cap 9, add an additional option "full"
     static final String INSETS_HANDLING_CSS = "css";
     static final String INSETS_HANDLING_DISABLE = "disable";
 
@@ -53,7 +55,7 @@ public class SystemBars extends Plugin {
         capacitorSystemBarsCheckMetaViewport();
         """;
 
-    private boolean insetHandlingEnabled = true;
+    private String insetsHandling = INSETS_HANDLING_CSS;
     private boolean hasViewportCover = false;
 
     private String currentStatusBarStyle = STYLE_DEFAULT;
@@ -94,9 +96,15 @@ public class SystemBars extends Plugin {
         String style = getConfig().getString("style", STYLE_DEFAULT).toUpperCase(Locale.US);
         boolean hidden = getConfig().getBoolean("hidden", false);
 
-        String insetsHandling = getConfig().getString("insetsHandling", "css");
-        if (insetsHandling.equals(INSETS_HANDLING_DISABLE)) {
-            insetHandlingEnabled = false;
+        String configuredInsetsHandling = getConfig().getString("insetsHandling", INSETS_HANDLING_CSS);
+        if (INSETS_HANDLING_CSS.equals(configuredInsetsHandling) || INSETS_HANDLING_DISABLE.equals(configuredInsetsHandling)) {
+            insetsHandling = configuredInsetsHandling;
+        } else {
+            Logger.warn(
+                "SystemBars",
+                "Unknown insetsHandling value '" + configuredInsetsHandling + "'. Falling back to '" + INSETS_HANDLING_CSS + "'."
+            );
+            insetsHandling = INSETS_HANDLING_CSS;
         }
 
         initWindowInsetsListener();
@@ -146,13 +154,15 @@ public class SystemBars extends Plugin {
 
     @JavascriptInterface
     public void onDOMReady() {
-        getActivity().runOnUiThread(() -> {
-            this.bridge.getWebView().evaluateJavascript(viewportMetaJSFunction, (res) -> {
-                hasViewportCover = res.equals("true");
+        if (INSETS_HANDLING_CSS.equals(insetsHandling)) {
+            getActivity().runOnUiThread(() -> {
+                this.bridge.getWebView().evaluateJavascript(viewportMetaJSFunction, (res) -> {
+                    hasViewportCover = res.equals("true");
 
-                getBridge().getWebView().requestApplyInsets();
+                    getBridge().getWebView().requestApplyInsets();
+                });
             });
-        });
+        }
     }
 
     private Insets calcSafeAreaInsets(WindowInsetsCompat insets) {
@@ -164,22 +174,28 @@ public class SystemBars extends Plugin {
     }
 
     private void initSafeAreaCSSVariables() {
-        WindowInsetsCompat insets;
+        if (INSETS_HANDLING_CSS.equals(insetsHandling)) {
+            WindowInsetsCompat insets;
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-            View v = (View) this.getBridge().getWebView().getParent();
-            insets = ViewCompat.getRootWindowInsets(v);
-        } else {
-            insets = WindowInsetsCompat.CONSUMED;
-        }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                View v = (View) this.getBridge().getWebView().getParent();
+                insets = ViewCompat.getRootWindowInsets(v);
+            } else {
+                insets = WindowInsetsCompat.CONSUMED;
+            }
 
-        if (insets != null) {
-            Insets safeAreaInsets = calcSafeAreaInsets(insets);
-            injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
+            if (insets != null) {
+                Insets safeAreaInsets = calcSafeAreaInsets(insets);
+                injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
+            }
         }
     }
 
     private void initWindowInsetsListener() {
+        if (INSETS_HANDLING_DISABLE.equals(insetsHandling)) {
+            return;
+        }
+
         ViewCompat.setOnApplyWindowInsetsListener((View) getBridge().getWebView().getParent(), (v, insets) -> {
             boolean shouldPassthroughInsets = getWebViewMajorVersion() >= WEBVIEW_VERSION_WITH_SAFE_AREA_FIX && hasViewportCover;
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -304,19 +304,21 @@ public class SystemBars extends Plugin {
         WindowInsetsControllerCompat windowInsetsControllerCompat = WindowCompat.getInsetsController(window, window.getDecorView());
 
         if (hide) {
-            if (bar.isEmpty() || bar.equals(BAR_STATUS_BAR)) {
+            if (bar.isEmpty()) {
+                windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.systemBars());
+            } else if (bar.equals(BAR_STATUS_BAR)) {
                 windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.statusBars());
-            }
-            if (bar.isEmpty() || bar.equals(BAR_GESTURE_BAR)) {
+            } else if (bar.equals(BAR_GESTURE_BAR)) {
                 windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.navigationBars());
             }
             return;
         }
 
-        if (bar.isEmpty() || bar.equals(BAR_STATUS_BAR)) {
+        if (bar.isEmpty()) {
             windowInsetsControllerCompat.show(WindowInsetsCompat.Type.systemBars());
-        }
-        if (bar.isEmpty() || bar.equals(BAR_GESTURE_BAR)) {
+        } else if (bar.equals(BAR_STATUS_BAR)) {
+            windowInsetsControllerCompat.show(WindowInsetsCompat.Type.statusBars());
+        } else if (bar.equals(BAR_GESTURE_BAR)) {
             windowInsetsControllerCompat.show(WindowInsetsCompat.Type.navigationBars());
         }
     }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
@@ -168,8 +168,8 @@ public class HttpRequestHandler {
                 "://" +
                 uri.getAuthority() +
                 uri.getPath() +
-                ((!urlQuery.equals("")) ? "?" + urlQuery : "") +
-                ((uri.getFragment() != null) ? uri.getFragment() : "");
+                (!urlQuery.equals("") ? "?" + urlQuery : "") +
+                (uri.getFragment() != null ? uri.getFragment() : "");
             this.url = new URL(unEncodedUrlString);
 
             return this;

--- a/android/capacitor/src/main/java/com/getcapacitor/util/JSONUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/util/JSONUtils.java
@@ -76,6 +76,26 @@ public class JSONUtils {
     }
 
     /**
+     * Get a double value from the given JSON object.
+     *
+     * @param jsonObject A JSON object to search
+     * @param key A key to fetch from the JSON object
+     * @param defaultValue A default value to return if the key cannot be found
+     * @return The value at the given key in the JSON object, or the default value
+     */
+    public static double getDouble(JSONObject jsonObject, String key, double defaultValue) {
+        String k = getDeepestKey(key);
+        try {
+            JSONObject o = getDeepestObject(jsonObject, key);
+            return o.getDouble(k);
+        } catch (JSONException ignore) {
+            // value was not found
+        }
+
+        return defaultValue;
+    }
+
+    /**
      * Get a JSON object value from the given JSON object.
      *
      * @param jsonObject A JSON object to search

--- a/android/capacitor/src/test/java/com/getcapacitor/ConfigBuildingTest.java
+++ b/android/capacitor/src/test/java/com/getcapacitor/ConfigBuildingTest.java
@@ -42,7 +42,7 @@ public class ConfigBuildingTest {
 
             config = new CapConfig.Builder(context)
                 .setAllowMixedContent(true)
-                .setAllowNavigation(new String[] {"http://www.google.com"})
+                .setAllowNavigation(new String[] { "http://www.google.com" })
                 .setAndroidScheme("test")
                 .setCaptureInput(true)
                 .setLoggingEnabled(true)
@@ -64,7 +64,7 @@ public class ConfigBuildingTest {
     @Test
     public void getCoreConfigValues() {
         assertTrue(config.isMixedContentAllowed());
-        assertArrayEquals(new String[] {"http://www.google.com"}, config.getAllowNavigation());
+        assertArrayEquals(new String[] { "http://www.google.com" }, config.getAllowNavigation());
         assertEquals("test", config.getAndroidScheme());
         assertTrue(config.isInputCaptured());
         assertTrue(config.isLoggingEnabled());
@@ -97,7 +97,7 @@ public class ConfigBuildingTest {
 
     @Test
     public void getPluginArray() {
-        String[] comparison = new String[] {"5", "6", "7", "8"};
+        String[] comparison = new String[] { "5", "6", "7", "8" };
         String[] testArray = config.getPluginConfiguration(TEST_PLUGIN_NAME).getArray("var5");
         assertArrayEquals(comparison, testArray);
     }

--- a/android/capacitor/src/test/java/com/getcapacitor/ConfigBuildingTest.java
+++ b/android/capacitor/src/test/java/com/getcapacitor/ConfigBuildingTest.java
@@ -42,7 +42,7 @@ public class ConfigBuildingTest {
 
             config = new CapConfig.Builder(context)
                 .setAllowMixedContent(true)
-                .setAllowNavigation(new String[] { "http://www.google.com" })
+                .setAllowNavigation(new String[] {"http://www.google.com"})
                 .setAndroidScheme("test")
                 .setCaptureInput(true)
                 .setLoggingEnabled(true)
@@ -64,7 +64,7 @@ public class ConfigBuildingTest {
     @Test
     public void getCoreConfigValues() {
         assertTrue(config.isMixedContentAllowed());
-        assertArrayEquals(new String[] { "http://www.google.com" }, config.getAllowNavigation());
+        assertArrayEquals(new String[] {"http://www.google.com"}, config.getAllowNavigation());
         assertEquals("test", config.getAndroidScheme());
         assertTrue(config.isInputCaptured());
         assertTrue(config.isLoggingEnabled());
@@ -97,7 +97,7 @@ public class ConfigBuildingTest {
 
     @Test
     public void getPluginArray() {
-        String[] comparison = new String[] { "5", "6", "7", "8" };
+        String[] comparison = new String[] {"5", "6", "7", "8"};
         String[] testArray = config.getPluginConfiguration(TEST_PLUGIN_NAME).getArray("var5");
         assertArrayEquals(comparison, testArray);
     }

--- a/android/capacitor/src/test/java/com/getcapacitor/plugin/SystemBarsTest.java
+++ b/android/capacitor/src/test/java/com/getcapacitor/plugin/SystemBarsTest.java
@@ -1,0 +1,73 @@
+package com.getcapacitor.plugin;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.view.View;
+import android.view.Window;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
+import com.getcapacitor.Bridge;
+import java.lang.reflect.Method;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+public class SystemBarsTest {
+
+    @Test
+    public void showWithEmptyBarShowsSystemBars() throws Exception {
+        WindowInsetsControllerCompat controller = invokeSetHidden("");
+
+        verify(controller).show(WindowInsetsCompat.Type.systemBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.statusBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.navigationBars());
+    }
+
+    @Test
+    public void showWithStatusBarShowsOnlyStatusBars() throws Exception {
+        WindowInsetsControllerCompat controller = invokeSetHidden("StatusBar");
+
+        verify(controller).show(WindowInsetsCompat.Type.statusBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.systemBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.navigationBars());
+    }
+
+    @Test
+    public void showWithNavigationBarShowsOnlyNavigationBars() throws Exception {
+        WindowInsetsControllerCompat controller = invokeSetHidden("NavigationBar");
+
+        verify(controller).show(WindowInsetsCompat.Type.navigationBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.systemBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.statusBars());
+    }
+
+    private WindowInsetsControllerCompat invokeSetHidden(String bar) throws Exception {
+        SystemBars plugin = new SystemBars();
+        Bridge bridge = mock(Bridge.class);
+        AppCompatActivity activity = mock(AppCompatActivity.class);
+        Window window = mock(Window.class);
+        View decorView = mock(View.class);
+        WindowInsetsControllerCompat controller = mock(WindowInsetsControllerCompat.class);
+
+        when(bridge.getActivity()).thenReturn(activity);
+        when(activity.getWindow()).thenReturn(window);
+        when(window.getDecorView()).thenReturn(decorView);
+
+        plugin.setBridge(bridge);
+
+        try (MockedStatic<WindowCompat> windowCompat = mockStatic(WindowCompat.class)) {
+            windowCompat.when(() -> WindowCompat.getInsetsController(window, decorView)).thenReturn(controller);
+
+            Method setHidden = SystemBars.class.getDeclaredMethod("setHidden", boolean.class, String.class);
+            setHidden.setAccessible(true);
+            setHidden.invoke(plugin, false, bar);
+        }
+
+        return controller;
+    }
+}

--- a/android/package.json
+++ b/android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/android",
-  "version": "8.3.2",
+  "version": "8.3.3",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/android/package.json
+++ b/android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/android",
-  "version": "8.3.3",
+  "version": "8.3.4",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/android/package.json
+++ b/android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/android",
-  "version": "8.3.1",
+  "version": "8.3.2",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/android/package.json
+++ b/android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/android",
-  "version": "8.4.0",
+  "version": "8.4.1",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/android/package.json
+++ b/android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/android",
-  "version": "8.3.4",
+  "version": "8.4.0",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",
@@ -23,7 +23,7 @@
     "verify": "./gradlew clean lint build test -b capacitor/build.gradle"
   },
   "peerDependencies": {
-    "@capacitor/core": "^8.3.0"
+    "@capacitor/core": "^8.4.0"
   },
   "publishConfig": {
     "access": "public"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.3](https://github.com/ionic-team/capacitor/compare/8.3.2...8.3.3) (2026-05-08)
+
+### Bug Fixes
+
+- **cli:** copy plugin files in CocoaPods projects ([#8467](https://github.com/ionic-team/capacitor/issues/8467)) ([b2d7719](https://github.com/ionic-team/capacitor/commit/b2d771926a180e60deea31992d7d4abcd5ca3bc7))
+
 ## [8.3.2](https://github.com/ionic-team/capacitor/compare/8.3.1...8.3.2) (2026-05-07)
 
 ### Bug Fixes

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.2](https://github.com/ionic-team/capacitor/compare/8.3.1...8.3.2) (2026-05-07)
+
+### Bug Fixes
+
+- **cli:** add cSettings support for compiler flags in generated Package.swift ([#8448](https://github.com/ionic-team/capacitor/issues/8448)) ([0bd0676](https://github.com/ionic-team/capacitor/commit/0bd0676315c5fd77e50312dd7b5bf4990dcbd7d0))
+- **cli:** add system framework and weak framework support in SPM Package.swift ([#8447](https://github.com/ionic-team/capacitor/issues/8447)) ([3232f0f](https://github.com/ionic-team/capacitor/commit/3232f0fe1d9811b0b5c500e3dc05cb8a250177f8))
+- **cli:** correct Capacitor plugin SPM compat check ([#8440](https://github.com/ionic-team/capacitor/issues/8440)) ([e5ccc45](https://github.com/ionic-team/capacitor/commit/e5ccc451dda27d56bca824ed644bd20fe4d988cb))
+- **cli:** generate binaryTarget entries for custom xcframeworks in Package.swift ([#8445](https://github.com/ionic-team/capacitor/issues/8445)) ([1f7e33f](https://github.com/ionic-team/capacitor/commit/1f7e33fca43d183332ec19d22b0d75ef81d8cc6d))
+- **cli:** generate resource entries in Package.swift ([#8455](https://github.com/ionic-team/capacitor/issues/8455)) ([790bd27](https://github.com/ionic-team/capacitor/commit/790bd27123497111984227010c3162cec94a108e))
+- **cli:** handle Cordova plugins without iOS source files ([#8443](https://github.com/ionic-team/capacitor/issues/8443)) ([0da130e](https://github.com/ionic-team/capacitor/commit/0da130eb7a861bee4e2c35bc0aac53ba9c983fc3))
+- **cli:** link plugin dependencies in Package.swift ([#8457](https://github.com/ionic-team/capacitor/issues/8457)) ([b3c769e](https://github.com/ionic-team/capacitor/commit/b3c769e856c826b1174518877cf86ac7ce73bf09))
+- **ios:** support Cordova plugins with Package.swift ([#8438](https://github.com/ionic-team/capacitor/issues/8438)) ([139943b](https://github.com/ionic-team/capacitor/commit/139943b0c05fddb2d1ce2d6f468800fddf17b4cf))
+
 ## [8.3.1](https://github.com/ionic-team/capacitor/compare/8.3.0...8.3.1) (2026-04-16)
 
 ### Bug Fixes

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.4](https://github.com/ionic-team/capacitor/compare/8.3.3...8.3.4) (2026-05-12)
+
+**Note:** Version bump only for package @capacitor/cli
+
 ## [8.3.3](https://github.com/ionic-team/capacitor/compare/8.3.2...8.3.3) (2026-05-08)
 
 ### Bug Fixes

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.4.1](https://github.com/ionic-team/capacitor/compare/8.4.0...8.4.1) (2026-06-19)
+
+### Bug Fixes
+
+- **cli:** make SPM dependency patch work on prereleases ([#8508](https://github.com/ionic-team/capacitor/issues/8508)) ([6048e90](https://github.com/ionic-team/capacitor/commit/6048e90171afa0229a3c25b52a23c377c6bb804c))
+- **cli:** patch Capacitor SPM dependency version in plugins ([#8492](https://github.com/ionic-team/capacitor/issues/8492)) ([28bb2c6](https://github.com/ionic-team/capacitor/commit/28bb2c687069dfdd6aa7abc866004a1c6388d103))
+
 # [8.4.0](https://github.com/ionic-team/capacitor/compare/8.3.4...8.4.0) (2026-06-02)
 
 ### Bug Fixes

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.4.0](https://github.com/ionic-team/capacitor/compare/8.3.4...8.4.0) (2026-06-02)
+
+### Bug Fixes
+
+- **cli:** revert live reload config on failure ([#8485](https://github.com/ionic-team/capacitor/issues/8485)) ([1d031a4](https://github.com/ionic-team/capacitor/commit/1d031a4abec2c793079ba8897ad2e40c4cc6c7f9))
+
+### Features
+
+- **cli:** add experimental packageOptions ([#8471](https://github.com/ionic-team/capacitor/issues/8471)) ([258867b](https://github.com/ionic-team/capacitor/commit/258867b7bf37b1837b99b02ec9638e5a6df08d97))
+- **cli:** capture ios_package_manager in telemetry ([#8482](https://github.com/ionic-team/capacitor/issues/8482)) ([b4b297a](https://github.com/ionic-team/capacitor/commit/b4b297a52f8732659662d5e5aaeff81c0f7d9835))
+
 ## [8.3.4](https://github.com/ionic-team/capacitor/compare/8.3.3...8.3.4) (2026-05-12)
 
 **Note:** Version bump only for package @capacitor/cli

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/cli",
-  "version": "8.3.2",
+  "version": "8.3.3",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/cli",
-  "version": "8.3.3",
+  "version": "8.3.4",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/cli",
-  "version": "8.3.1",
+  "version": "8.3.2",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/cli",
-  "version": "8.3.4",
+  "version": "8.4.0",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/cli",
-  "version": "8.4.0",
+  "version": "8.4.1",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -559,6 +559,13 @@ export interface CapacitorConfig {
          * @since 8.3.0
          */
         packageTraits?: { [pluginId: string]: string[] };
+        /**
+         * Define options to apply to the package.
+         * The key is the plugin ID (e.g. `@capacitor-community/device`)
+         *
+         * @since 8.4.0
+         */
+        packageOptions?: { [pluginId: string]: PackageOptions };
       };
     };
   };
@@ -798,4 +805,17 @@ export interface PluginsConfig {
      */
     animation?: 'FADE' | 'NONE';
   };
+}
+
+export interface PackageOptions {
+  /**
+   * Create a symlink to the plugin folder instead of pointing to the plugin path.
+   * Useful when plugin names conflict.
+   */
+  symlink?: boolean;
+  /**
+   * Useful to avoid target name conflicts in dependencies
+   * [see](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/modulealiasing/)
+   */
+  moduleAliases?: { [target: string]: string };
 }

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -604,7 +604,7 @@ export interface CapacitorConfig {
      * Configure the local scheme on Android.
      *
      * Custom schemes on Android are unable to change the URL path as of Webview 117. Changing this value from anything other than `http` or `https` can result in your
-     * application unable to resolve routing. If you must change this for some reason, consider using a hash-based url strategy, but there are no guarentees that this
+     * application unable to resolve routing. If you must change this for some reason, consider using a hash-based url strategy, but there are no guarantees that this
      * will continue to work long term as allowing non-standard schemes to modify query parameters and url fragments is only allowed for compatibility reasons.
      * https://ionic.io/blog/capacitor-android-customscheme-issue-with-chrome-117
      *

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -639,6 +639,9 @@ async function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) 
 
 async function removePluginsNativeFiles(config: Config) {
   await remove(config.ios.cordovaPluginsDirAbs);
+  if ((await config.ios.packageManager) === 'SPM') {
+    await remove(join(config.ios.nativeProjectDirAbs, 'CapApp-SPM', 'symlinks'));
+  }
   await extractTemplate(config.cli.assets.ios.cordovaPluginsTemplateArchiveAbs, config.ios.cordovaPluginsDirAbs);
 }
 

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -564,7 +564,7 @@ async function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) 
   const isSPM = (await config.ios.packageManager) === 'SPM';
   for (const p of cordovaPlugins) {
     const platformTag = getPluginPlatform(p, platform);
-    if (platformTag.$?.package) {
+    if (isSPM && platformTag.$?.package) {
       continue;
     }
     const sourceFiles = getPlatformElement(p, platform, 'source-file');

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -1,6 +1,6 @@
 import { copy, remove, pathExists, readFile, realpath, writeFile } from 'fs-extra';
 import { basename, dirname, join, relative } from 'path';
-import { major } from 'semver';
+import { major, prerelease } from 'semver';
 
 import c from '../colors';
 import { checkPlatformVersions, getCapacitorPackageVersion, runTask } from '../common';
@@ -70,11 +70,13 @@ async function updatePluginFiles(config: Config, plugins: Plugin[], deployment: 
         const version = content.match(regex)?.[1];
         const majorCapVersion = major(iosPlatformVersion);
         if (version && major(version) != majorCapVersion) {
+          const preCapVersion = prerelease(iosPlatformVersion);
+          const forceVersion = preCapVersion ? iosPlatformVersion : `${majorCapVersion}.0.0`;
           content = setAllStringIn(
             content,
             `url: "https://github.com/ionic-team/capacitor-swift-pm.git",`,
             `)`,
-            ` from: "${majorCapVersion}.0.0"`,
+            ` from: "${forceVersion}"`,
           );
           await writeFile(packageSwiftPath, content);
           logger.warn(`${plugin.id} is built for Capacitor ${major(version)}, it might cause issues`);

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -1,5 +1,6 @@
 import { copy, remove, pathExists, readFile, realpath, writeFile } from 'fs-extra';
 import { basename, dirname, join, relative } from 'path';
+import { major } from 'semver';
 
 import c from '../colors';
 import { checkPlatformVersions, getCapacitorPackageVersion, runTask } from '../common';
@@ -58,6 +59,28 @@ async function updatePluginFiles(config: Config, plugins: Plugin[], deployment: 
     await generateCordovaPackageFiles(cordovaPlugins, config);
 
     const validSPMPackages = await checkPluginsForPackageSwift(config, plugins);
+    await Promise.all(
+      validSPMPackages.map(async (plugin) => {
+        const iosPlatformVersion = await getCapacitorPackageVersion(config, config.ios.name);
+        const packageSwiftPath = join(plugin.rootPath, 'Package.swift');
+        let content = await readFile(packageSwiftPath, { encoding: 'utf-8' });
+        const regex = new RegExp(
+          'url:\\s*"https://github.com/ionic-team/capacitor-swift-pm\\.git",\\s*from:\\s*"([^"]+)"',
+        );
+        const version = content.match(regex)?.[1];
+        const majorCapVersion = major(iosPlatformVersion);
+        if (version && major(version) != majorCapVersion) {
+          content = setAllStringIn(
+            content,
+            `url: "https://github.com/ionic-team/capacitor-swift-pm.git",`,
+            `)`,
+            ` from: "${majorCapVersion}.0.0"`,
+          );
+          await writeFile(packageSwiftPath, content);
+          logger.warn(`${plugin.id} is built for Capacitor ${major(version)}, it might cause issues`);
+        }
+      }),
+    );
 
     await generatePackageFile(config, validSPMPackages.concat(cordovaPlugins));
   } else {

--- a/cli/src/ipc.ts
+++ b/cli/src/ipc.ts
@@ -49,9 +49,9 @@ export async function receive(msg: IPCMessage): Promise<void> {
     // This request is only made if telemetry is on.
     const req = request(
       {
-        hostname: 'api.ionicjs.com',
+        hostname: 'metrics-capacitor.outsystems.com',
         port: 443,
-        path: '/events/metrics',
+        path: '/metrics',
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -60,7 +60,7 @@ export async function receive(msg: IPCMessage): Promise<void> {
       (response) => {
         debug('Sent %O metric to events service (status: %O)', data.name, response.statusCode);
 
-        if (response.statusCode !== 204) {
+        if (response.statusCode !== 202) {
           response.on('data', (chunk) => {
             debug('Bad response from events service. Request body: %O', chunk.toString());
           });

--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -116,6 +116,9 @@ export async function runCommand(
         await sleepForever();
       }
     } catch (e: any) {
+      if (options.liveReload) {
+        await CapLiveReloadHelper.revertCapConfigForLiveReload();
+      }
       if (!isFatal(e)) {
         fatal(e.stack ?? e);
       }

--- a/cli/src/telemetry.ts
+++ b/cli/src/telemetry.ts
@@ -1,8 +1,9 @@
 import { Command } from 'commander';
 import Debug from 'debug';
+import { pathExists } from 'fs-extra';
 
 import c from './colors';
-import type { Config } from './definitions';
+import type { Config, PackageManager } from './definitions';
 import { send } from './ipc';
 import { output } from './log';
 import { readConfig, writeConfig } from './sysconfig';
@@ -26,6 +27,7 @@ export interface CommandMetricData {
   error: string | null;
   node_version: string;
   os: string;
+  ios_package_manager: PackageManager | 'unknown';
 }
 
 export interface Metric<N extends string, D> {
@@ -80,8 +82,11 @@ export function telemetryAction(config: Config, action: CommanderAction): Comman
       error: error ? (error.message ? error.message : String(error)) : null,
       node_version: process.version,
       os: config.cli.os,
+      ios_package_manager: await getIOSPackageManager(config),
       ...Object.fromEntries(versions),
     };
+
+    debug('metric payload: %O', data);
 
     if (isInteractive()) {
       let sysconfig = await readConfig();
@@ -123,6 +128,24 @@ export async function sendMetric<D>(
     await send({ type: 'telemetry', data: message });
   } else {
     debug('Telemetry is off (user choice, non-interactive terminal, or CI)--not sending metric');
+  }
+}
+
+/**
+ * Resolve the iOS dependency manager for telemetry. Returns 'unknown' for
+ * non-iOS projects or when detection throws, so callers never have to handle
+ * errors from this signal.
+ */
+export async function getIOSPackageManager(config: Config): Promise<PackageManager | 'unknown'> {
+  try {
+    if (!(await pathExists(config.ios.platformDirAbs))) {
+      return 'unknown';
+    }
+
+    return await config.ios.packageManager;
+  } catch (e) {
+    debug('Could not resolve iOS package manager for telemetry: %O', e);
+    return 'unknown';
   }
 }
 

--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -1,4 +1,4 @@
-import { pathExists, existsSync, readFileSync, writeFileSync, remove, move, mkdtemp } from 'fs-extra';
+import { ensureSymlink, pathExists, existsSync, readFileSync, writeFileSync, remove, move, mkdtemp } from 'fs-extra';
 import { tmpdir } from 'os';
 import { join, relative, resolve } from 'path';
 import type { PlistObject } from 'plist';
@@ -100,6 +100,7 @@ export async function generatePackageText(config: Config, plugins: Plugin[]): Pr
   const iosPlatformVersion = await getCapacitorPackageVersion(config, config.ios.name);
   const iosVersion = getMajoriOSVersion(config);
   const packageTraits = config.app.extConfig.experimental?.ios?.spm?.packageTraits ?? {};
+  const packageOptions = config.app.extConfig.experimental?.ios?.spm?.packageOptions ?? {};
   const swiftToolsVersion = config.app.extConfig.experimental?.ios?.spm?.swiftToolsVersion ?? '5.9';
 
   let packageSwiftText = `// swift-tools-version: ${swiftToolsVersion}
@@ -132,7 +133,13 @@ let package = Package(
         packageSwiftText += `,\n        .package(name: "${plugin.name}", path: "../../capacitor-cordova-ios-plugins/sources/${plugin.name}")`;
       }
     } else {
-      const relPath = relative(config.ios.nativeXcodeProjDirAbs, plugin.rootPath);
+      const options = packageOptions[plugin.id];
+      const symlink = options?.symlink;
+      const symlinkFolder = join('symlinks', plugin.name);
+      const relPath = symlink ? symlinkFolder : relative(config.ios.nativeXcodeProjDirAbs, plugin.rootPath);
+      if (symlink) {
+        await ensureSymlink(plugin.rootPath, resolve(config.ios.nativeProjectDirAbs, 'CapApp-SPM', symlinkFolder));
+      }
       const traits = packageTraits[plugin.id];
       const traitsSuffix = traits?.length
         ? `, traits: [${traits
@@ -156,7 +163,15 @@ let package = Package(
                 .product(name: "Cordova", package: "capacitor-swift-pm")`;
 
   for (const plugin of plugins) {
-    let pluginText = `,\n                .product(name: "${plugin.ios?.name}", package: "${plugin.ios?.name}")`;
+    const aliases = Object.entries(packageOptions[plugin.id]?.moduleAliases ?? {});
+    const aliasText = aliases?.length
+      ? `, moduleAliases:  [${aliases
+          .map(([target, replacement]) => {
+            return `"${target}": "${replacement}"`;
+          })
+          .join(', ')}]`
+      : '';
+    let pluginText = `,\n                .product(name: "${plugin.ios?.name}", package: "${plugin.ios?.name}"${aliasText})`;
     if (getPluginType(plugin, config.ios.name) === PluginType.Cordova) {
       const platformTag = getPluginPlatform(plugin, config.ios.name);
       if (platformTag.$?.package) {

--- a/cli/test/telemetry.spec.ts
+++ b/cli/test/telemetry.spec.ts
@@ -1,0 +1,60 @@
+import { pathExists } from 'fs-extra';
+
+import type { Config, IOSConfig } from '../src/definitions';
+import { getIOSPackageManager } from '../src/telemetry';
+
+jest.mock('fs-extra', () => ({
+  pathExists: jest.fn(),
+}));
+
+const mockedPathExists = pathExists as unknown as jest.Mock;
+
+function makeConfig(ios: Partial<IOSConfig>): Config {
+  return { ios } as unknown as Config;
+}
+
+describe('getIOSPackageManager', () => {
+  beforeEach(() => {
+    mockedPathExists.mockReset();
+  });
+
+  it('returns "unknown" when the iOS platform directory does not exist', async () => {
+    mockedPathExists.mockResolvedValueOnce(false);
+
+    const result = await getIOSPackageManager(
+      makeConfig({
+        platformDirAbs: '/tmp/no-such-dir/ios',
+        packageManager: Promise.resolve('SPM'),
+      }),
+    );
+
+    expect(result).toBe('unknown');
+    expect(mockedPathExists).toHaveBeenCalledWith('/tmp/no-such-dir/ios');
+  });
+
+  it('returns the resolved package manager when iOS is present', async () => {
+    mockedPathExists.mockResolvedValueOnce(true);
+
+    const result = await getIOSPackageManager(
+      makeConfig({
+        platformDirAbs: '/tmp/app/ios',
+        packageManager: Promise.resolve('SPM'),
+      }),
+    );
+
+    expect(result).toBe('SPM');
+  });
+
+  it('returns "unknown" when packageManager resolution throws', async () => {
+    mockedPathExists.mockResolvedValueOnce(true);
+
+    const result = await getIOSPackageManager(
+      makeConfig({
+        platformDirAbs: '/tmp/app/ios',
+        packageManager: Promise.reject(new Error('boom')),
+      }),
+    );
+
+    expect(result).toBe('unknown');
+  });
+});

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.4](https://github.com/ionic-team/capacitor/compare/8.3.3...8.3.4) (2026-05-12)
+
+**Note:** Version bump only for package @capacitor/core
+
 ## [8.3.3](https://github.com/ionic-team/capacitor/compare/8.3.2...8.3.3) (2026-05-08)
 
 **Note:** Version bump only for package @capacitor/core

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.3](https://github.com/ionic-team/capacitor/compare/8.3.2...8.3.3) (2026-05-08)
+
+**Note:** Version bump only for package @capacitor/core
+
 ## [8.3.2](https://github.com/ionic-team/capacitor/compare/8.3.1...8.3.2) (2026-05-07)
 
 **Note:** Version bump only for package @capacitor/core

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.2](https://github.com/ionic-team/capacitor/compare/8.3.1...8.3.2) (2026-05-07)
+
+**Note:** Version bump only for package @capacitor/core
+
 ## [8.3.1](https://github.com/ionic-team/capacitor/compare/8.3.0...8.3.1) (2026-04-16)
 
 **Note:** Version bump only for package @capacitor/core

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.4.0](https://github.com/ionic-team/capacitor/compare/8.3.4...8.4.0) (2026-06-02)
+
+**Note:** Version bump only for package @capacitor/core
+
 ## [8.3.4](https://github.com/ionic-team/capacitor/compare/8.3.3...8.3.4) (2026-05-12)
 
 **Note:** Version bump only for package @capacitor/core

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.4.1](https://github.com/ionic-team/capacitor/compare/8.4.0...8.4.1) (2026-06-19)
+
+**Note:** Version bump only for package @capacitor/core
+
 # [8.4.0](https://github.com/ionic-team/capacitor/compare/8.3.4...8.4.0) (2026-06-02)
 
 **Note:** Version bump only for package @capacitor/core

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/core",
-  "version": "8.3.1",
+  "version": "8.3.2",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/core",
-  "version": "8.3.3",
+  "version": "8.3.4",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/core",
-  "version": "8.3.2",
+  "version": "8.3.3",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/core",
-  "version": "8.3.4",
+  "version": "8.4.0",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/core",
-  "version": "8.4.0",
+  "version": "8.4.1",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/ios-pods-template/App/App.xcodeproj/project.pbxproj
+++ b/ios-pods-template/App/App.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2FAD9763203C412B000D30F8 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 2FAD9762203C412B000D30F8 /* config.xml */; };
 		50379B232058CBB4000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B222058CBB4000EE86E /* capacitor.config.json */; };
 		504EC3081FED79650016851F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3071FED79650016851F /* AppDelegate.swift */; };
+		2C6EFDE1674F365EA0601FC0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6197F4D7F73A0E1131CB2963 /* SceneDelegate.swift */; };
 		504EC30D1FED79650016851F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30B1FED79650016851F /* Main.storyboard */; };
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
@@ -22,6 +23,7 @@
 		50379B222058CBB4000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		504EC3041FED79650016851F /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		504EC3071FED79650016851F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		6197F4D7F73A0E1131CB2963 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		504EC30C1FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		504EC30E1FED79650016851F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -75,6 +77,7 @@
 			children = (
 				50379B222058CBB4000EE86E /* capacitor.config.json */,
 				504EC3071FED79650016851F /* AppDelegate.swift */,
+				6197F4D7F73A0E1131CB2963 /* SceneDelegate.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -210,6 +213,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				2C6EFDE1674F365EA0601FC0 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios-pods-template/App/App/AppDelegate.swift
+++ b/ios-pods-template/App/App/AppDelegate.swift
@@ -46,4 +46,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return ApplicationDelegateProxy.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
     }
 
+    // MARK: UIScene life cycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called
+        // shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they
+        // will not return.
+    }
+
 }

--- a/ios-pods-template/App/App/Info.plist
+++ b/ios-pods-template/App/App/Info.plist
@@ -22,6 +22,25 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/ios-pods-template/App/App/SceneDelegate.swift
+++ b/ios-pods-template/App/App/SceneDelegate.swift
@@ -1,0 +1,46 @@
+import UIKit
+
+/// Adopts the UIWindowScene-based life cycle required by newer iOS SDKs (see the
+/// `UIApplicationSceneManifest` entry in Info.plist). Without this class and the
+/// corresponding manifest entry, apps built with a scene-lifecycle-requiring SDK
+/// fail to launch (UIKit logs "UIScene life cycle is required for apps built with
+/// this SDK") even though no crash log is produced.
+///
+/// See: https://developer.apple.com/documentation/technotes/tn3187-migrating-to-the-uikit-scene-based-life-cycle
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // The root view controller (CAPBridgeViewController, via Main.storyboard) is configured
+        // automatically from UISceneStoryboardFile in Info.plist, so no manual window/root view
+        // controller setup is required here.
+        guard scene is UIWindowScene else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific
+        // state information to restore the scene back to its current state.
+    }
+}

--- a/ios-spm-template/App/App.xcodeproj/project.pbxproj
+++ b/ios-spm-template/App/App.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		4D22ABE92AF431CB00220026 /* CapApp-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 4D22ABE82AF431CB00220026 /* CapApp-SPM */; };
 		50379B232058CBB4000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B222058CBB4000EE86E /* capacitor.config.json */; };
 		504EC3081FED79650016851F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3071FED79650016851F /* AppDelegate.swift */; };
+		785D74E6F5C248B56B0A9CF9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A43193715767FB78F37E3E9 /* SceneDelegate.swift */; };
 		504EC30D1FED79650016851F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30B1FED79650016851F /* Main.storyboard */; };
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
@@ -22,6 +23,7 @@
 		50379B222058CBB4000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		504EC3041FED79650016851F /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		504EC3071FED79650016851F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		8A43193715767FB78F37E3E9 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		504EC30C1FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		504EC30E1FED79650016851F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -64,6 +66,7 @@
 			children = (
 				50379B222058CBB4000EE86E /* capacitor.config.json */,
 				504EC3071FED79650016851F /* AppDelegate.swift */,
+				8A43193715767FB78F37E3E9 /* SceneDelegate.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -156,6 +159,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				785D74E6F5C248B56B0A9CF9 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios-spm-template/App/App/AppDelegate.swift
+++ b/ios-spm-template/App/App/AppDelegate.swift
@@ -46,4 +46,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return ApplicationDelegateProxy.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
     }
 
+    // MARK: UIScene life cycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called
+        // shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they
+        // will not return.
+    }
+
 }

--- a/ios-spm-template/App/App/Info.plist
+++ b/ios-spm-template/App/App/Info.plist
@@ -24,6 +24,25 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/ios-spm-template/App/App/SceneDelegate.swift
+++ b/ios-spm-template/App/App/SceneDelegate.swift
@@ -1,0 +1,46 @@
+import UIKit
+
+/// Adopts the UIWindowScene-based life cycle required by newer iOS SDKs (see the
+/// `UIApplicationSceneManifest` entry in Info.plist). Without this class and the
+/// corresponding manifest entry, apps built with a scene-lifecycle-requiring SDK
+/// fail to launch (UIKit logs "UIScene life cycle is required for apps built with
+/// this SDK") even though no crash log is produced.
+///
+/// See: https://developer.apple.com/documentation/technotes/tn3187-migrating-to-the-uikit-scene-based-life-cycle
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // The root view controller (CAPBridgeViewController, via Main.storyboard) is configured
+        // automatically from UISceneStoryboardFile in Info.plist, so no manual window/root view
+        // controller setup is required here.
+        guard scene is UIWindowScene else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific
+        // state information to restore the scene back to its current state.
+    }
+}

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.3](https://github.com/ionic-team/capacitor/compare/8.3.2...8.3.3) (2026-05-08)
+
+**Note:** Version bump only for package @capacitor/ios
+
 ## [8.3.2](https://github.com/ionic-team/capacitor/compare/8.3.1...8.3.2) (2026-05-07)
 
 **Note:** Version bump only for package @capacitor/ios

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.2](https://github.com/ionic-team/capacitor/compare/8.3.1...8.3.2) (2026-05-07)
+
+**Note:** Version bump only for package @capacitor/ios
+
 ## [8.3.1](https://github.com/ionic-team/capacitor/compare/8.3.0...8.3.1) (2026-04-16)
 
 ### Bug Fixes

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.4](https://github.com/ionic-team/capacitor/compare/8.3.3...8.3.4) (2026-05-12)
+
+**Note:** Version bump only for package @capacitor/ios
+
 ## [8.3.3](https://github.com/ionic-team/capacitor/compare/8.3.2...8.3.3) (2026-05-08)
 
 **Note:** Version bump only for package @capacitor/ios

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.4.1](https://github.com/ionic-team/capacitor/compare/8.4.0...8.4.1) (2026-06-19)
+
+**Note:** Version bump only for package @capacitor/ios
+
 # [8.4.0](https://github.com/ionic-team/capacitor/compare/8.3.4...8.4.0) (2026-06-02)
 
 ### Features

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.4.0](https://github.com/ionic-team/capacitor/compare/8.3.4...8.4.0) (2026-06-02)
+
+### Features
+
+- add method getDouble to plugin config ([#7638](https://github.com/ionic-team/capacitor/issues/7638)) ([93c72de](https://github.com/ionic-team/capacitor/commit/93c72de40a2ec4c78b33659250cb08340083088e))
+
 ## [8.3.4](https://github.com/ionic-team/capacitor/compare/8.3.3...8.3.4) (2026-05-12)
 
 **Note:** Version bump only for package @capacitor/ios

--- a/ios/Capacitor/Capacitor/PluginConfig.swift
+++ b/ios/Capacitor/Capacitor/PluginConfig.swift
@@ -30,6 +30,13 @@ import Foundation
         return defaultValue
     }
 
+    @objc public func getDouble(_ configKey: String, _ defaultValue: Double) -> Double {
+        if let val = (self.config)[keyPath: KeyPath(configKey)] as? Double {
+            return val
+        }
+        return defaultValue
+    }
+
     public func getArray(_ configKey: String, _ defaultValue: JSArray? = nil) -> JSArray? {
         if let val = (self.config)[keyPath: KeyPath(configKey)] as? JSArray {
             return val

--- a/ios/package.json
+++ b/ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/ios",
-  "version": "8.3.1",
+  "version": "8.3.2",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/ios/package.json
+++ b/ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/ios",
-  "version": "8.3.2",
+  "version": "8.3.3",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/ios/package.json
+++ b/ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/ios",
-  "version": "8.3.3",
+  "version": "8.3.4",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/ios/package.json
+++ b/ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/ios",
-  "version": "8.3.4",
+  "version": "8.4.0",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",
@@ -25,7 +25,7 @@
     "xc:build:CapacitorCordova": "cd CapacitorCordova && xcodebuild && cd .."
   },
   "peerDependencies": {
-    "@capacitor/core": "^8.3.0"
+    "@capacitor/core": "^8.4.0"
   },
   "publishConfig": {
     "access": "public"

--- a/ios/package.json
+++ b/ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/ios",
-  "version": "8.4.0",
+  "version": "8.4.1",
   "description": "Capacitor: Cross-platform apps with JavaScript and the web",
   "homepage": "https://capacitorjs.com",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/lerna.json
+++ b/lerna.json
@@ -11,6 +11,6 @@
       "tagVersionPrefix": ""
     }
   },
-  "version": "8.3.1",
+  "version": "8.3.2",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -11,6 +11,6 @@
       "tagVersionPrefix": ""
     }
   },
-  "version": "8.3.3",
+  "version": "8.3.4",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -11,6 +11,6 @@
       "tagVersionPrefix": ""
     }
   },
-  "version": "8.3.2",
+  "version": "8.3.3",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -11,6 +11,6 @@
       "tagVersionPrefix": ""
     }
   },
-  "version": "8.3.4",
+  "version": "8.4.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -11,6 +11,6 @@
       "tagVersionPrefix": ""
     }
   },
-  "version": "8.4.0",
+  "version": "8.4.1",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }


### PR DESCRIPTION
## Merge Conflict Resolution Required

The sync of upstream PR #8527 from @nilspep encountered merge conflicts.

**Original PR:** https://github.com/ionic-team/capacitor/pull/8527

### What happened
- Claude Code attempted to resolve the merge conflicts
- This PR was created so CI and manual review can finish the sync safely

---
*Synced from upstream by Capacitor+ Bot*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving decimal configuration values in Android and iOS plugins.
  * Expanded iOS Swift Package Manager configuration with symlinks and module aliases.
  * Updated iOS app templates with modern scene lifecycle support.
  * Improved Android system bar and safe-area inset handling, including configurable CSS or disabled modes.

* **Bug Fixes**
  * Live-reload settings now revert correctly when commands fail.
  * Improved Android photo capture URI permissions.

* **Release**
  * Updated packages and release notes to version 8.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->