### PR TITLE
chore: sync upstream PR #8334 - fix(cli): `cap run` fails with renamed outputs for android

### DIFF
--- a/cli/src/android/run.ts
+++ b/cli/src/android/run.ts
@@ -54,7 +54,7 @@ export async function runAndroid(
     config.android.appDir
   }/build/outputs/apk${runFlavor !== '' ? '/' + runFlavor : ''}/debug`;
 
-  const apkName = parseApkNameFromFlavor(runFlavor);
+  const apkName = await parseApkNameFromFlavor(runFlavor, pathToApk);
   const apkPath = resolve(pathToApk, apkName);
 
   const nativeRunArgs = ['android', '--app', apkPath, '--target', target.id];

--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -536,7 +536,15 @@ export async function checkJDKMajorVersion(): Promise<number> {
   }
 }
 
-export function parseApkNameFromFlavor(flavor: string): string {
+export async function parseApkNameFromFlavor(flavor: string, pathToApk: string): Promise<string> {
+  if (!flavor) {
+        const metadataPath = join(pathToApk, 'output-metadata.json');
+        if (await pathExists(metadataPath)) {
+            const metadataContent = await readJSON(metadataPath);
+            if (metadataContent && metadataContent.elements && metadataContent.elements.length && metadataContent.elements[0].outputFile)
+              return metadataContent.elements[0].outputFile;
+        }
+    }
   let convertedName = flavor.replace(/([A-Z])/g, '-$1').toLowerCase();
 
   if (convertedName.startsWith('-')) convertedName = convertedName.replace('-', '');

--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -551,13 +551,13 @@ export async function checkJDKMajorVersion(): Promise<number> {
 
 export async function parseApkNameFromFlavor(flavor: string, pathToApk: string): Promise<string> {
   if (!flavor) {
-        const metadataPath = join(pathToApk, 'output-metadata.json');
-        if (await pathExists(metadataPath)) {
-            const metadataContent = await readJSON(metadataPath);
-            if (metadataContent && metadataContent.elements && metadataContent.elements.length && metadataContent.elements[0].outputFile)
-              return metadataContent.elements[0].outputFile;
-        }
+    const metadataPath = join(pathToApk, 'output-metadata.json');
+    if (await pathExists(metadataPath)) {
+      const metadataContent = await readJSON(metadataPath);
+      const outputFile = metadataContent?.elements?.[0]?.outputFile;
+      if (outputFile) return outputFile;
     }
+  }
   let convertedName = flavor.replace(/([A-Z])/g, '-$1').toLowerCase();
 
   if (convertedName.startsWith('-')) convertedName = convertedName.replace('-', '');

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -221,7 +221,7 @@ async function loadAndroidConfig(
   if (extConfig.android?.flavor) {
     apkPath = `${apkPath}/${extConfig.android?.flavor}`;
   }
-  const apkName = parseApkNameFromFlavor(flavor);
+  const apkName = await parseApkNameFromFlavor(flavor, `${platformDirAbs}/${apkPath}debug`);
   const buildOutputDir = `${apkPath}/debug`;
   const cordovaPluginsDir = 'capacitor-cordova-android-plugins';
   const studioPath = lazy(() => determineAndroidStudioPath(cliConfig.os));


### PR DESCRIPTION
## Upstream PR Sync

This PR syncs changes from an external contributor's PR on the official Capacitor repository.

### Original PR
- **PR:** [#8334](https://github.com/ionic-team/capacitor/pull/8334)
- **Title:** fix(cli): `cap run` fails with renamed outputs for android
- **Author:** @HASH-0021

### Automation
- CI will run automatically
- Manual review is required before merging
- Auto-merge is disabled until an equivalent review gate is available
- A new release will be published automatically

---
*Synced from upstream by Capacitor+ Bot*