### PR TITLE
chore: sync upstream PR #8271 - fix(core): prevent removeListener from removing wrong listener

### DIFF
--- a/core/src/tests/web-plugin.spec.ts
+++ b/core/src/tests/web-plugin.spec.ts
@@ -181,4 +181,30 @@ describe('Web Plugin', () => {
 
     expect(handlerFunction).not.toHaveBeenCalled();
   });
+
+  it('Should not remove a listener if it is not found', async () => {
+    const lf1 = (event: any) => {
+      console.log(event);
+    };
+    const lf2 = (event: any) => {
+      console.log(event);
+    };
+    const lf3 = (event: any) => {
+      console.log(event);
+    };
+
+    await plugin.addListener('test', lf1);
+    await plugin.addListener('test', lf2);
+
+    const listenersBefore = plugin.getListeners()['test'];
+    expect(listenersBefore.length).toEqual(2);
+
+    // Try to remove a listener that was never added
+    await (plugin as any).removeListener('test', lf3);
+
+    const listenersAfter = plugin.getListeners()['test'];
+    expect(listenersAfter.length).toEqual(2);
+    expect(listenersAfter[0]).toBe(lf1);
+    expect(listenersAfter[1]).toBe(lf2);
+  });
 });

--- a/core/src/web-plugin.ts
+++ b/core/src/web-plugin.ts
@@ -98,7 +98,9 @@ export class WebPlugin implements Plugin {
     }
 
     const index = listeners.indexOf(listenerFunc);
-    this.listeners[eventName].splice(index, 1);
+    if (index !== -1) {
+      this.listeners[eventName].splice(index, 1);
+    }
 
     // If there are no more listeners for this type of event,
     // remove the window listener


### PR DESCRIPTION
## Upstream PR Sync

This PR syncs changes from an external contributor's PR on the official Capacitor repository.

### Original PR
- **PR:** [#8271](https://github.com/ionic-team/capacitor/pull/8271)
- **Title:** fix(core): prevent removeListener from removing wrong listener
- **Author:** @maniktyagi04

### Automation
- CI will run automatically
- Manual review is required before merging
- Auto-merge is disabled until an equivalent review gate is available
- A new release will be published automatically

---
*Synced from upstream by Capacitor+ Bot*