### PR TITLE
chore(release): 8.3.10 — restore version sync and stop Bump version tag races

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -8,6 +8,12 @@ on:
       - '**.md'
       - '.github/**'
 
+# Two pushes landing close together would otherwise both compute the same next
+# patch version; the loser then dies on `git tag: already exists`.
+concurrency:
+  group: bump-version-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # Run all tests first before creating any tags
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.10](https://github.com/Cap-go/capacitor-plus/compare/8.3.9...8.3.10) (2026-08-13)
+
+**Note:** Version bump only for package capacitor
+
+
+
+
+
 ## [8.3.9](https://github.com/Cap-go/capacitor-plus/compare/8.3.8...8.3.9) (2026-08-13)
 
 **Note:** Version bump only for package capacitor

--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.10](https://github.com/Cap-go/capacitor-plus/compare/8.3.9...8.3.10) (2026-08-13)
+
+**Note:** Version bump only for package @capacitor-plus/android
+
+
+
+
+
 ## [8.3.9](https://github.com/Cap-go/capacitor-plus/compare/8.3.8...8.3.9) (2026-08-13)
 
 **Note:** Version bump only for package @capacitor-plus/android

--- a/android/package.json
+++ b/android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-plus/android",
-  "version": "8.3.9",
+  "version": "8.3.10",
   "description": "Capacitor+: Enhanced Capacitor with automated upstream sync - Cross-platform apps with JavaScript and the web",
   "homepage": "https://capgo.app/docs/plugins/capacitor-plus/",
   "author": "Capgo Team <support@capgo.app> (https://capgo.app)",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.10](https://github.com/Cap-go/capacitor-plus/compare/8.3.9...8.3.10) (2026-08-13)
+
+**Note:** Version bump only for package @capacitor-plus/cli
+
+
+
+
+
 ## [8.3.9](https://github.com/Cap-go/capacitor-plus/compare/8.3.8...8.3.9) (2026-08-13)
 
 **Note:** Version bump only for package @capacitor-plus/cli

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-plus/cli",
-  "version": "8.3.9",
+  "version": "8.3.10",
   "description": "Capacitor+: Enhanced Capacitor with automated upstream sync - Cross-platform apps with JavaScript and the web",
   "homepage": "https://capgo.app/docs/plugins/capacitor-plus/",
   "author": "Capgo Team <support@capgo.app> (https://capgo.app)",

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.10](https://github.com/Cap-go/capacitor-plus/compare/8.3.9...8.3.10) (2026-08-13)
+
+**Note:** Version bump only for package @capacitor-plus/core
+
+
+
+
+
 ## [8.3.9](https://github.com/Cap-go/capacitor-plus/compare/8.3.8...8.3.9) (2026-08-13)
 
 **Note:** Version bump only for package @capacitor-plus/core

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-plus/core",
-  "version": "8.3.9",
+  "version": "8.3.10",
   "description": "Capacitor+: Enhanced Capacitor with automated upstream sync - Cross-platform apps with JavaScript and the web",
   "homepage": "https://capgo.app/docs/plugins/capacitor-plus/",
   "author": "Capgo Team <support@capgo.app> (https://capgo.app)",

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.10](https://github.com/Cap-go/capacitor-plus/compare/8.3.9...8.3.10) (2026-08-13)
+
+**Note:** Version bump only for package @capacitor-plus/ios
+
+
+
+
+
 ## [8.3.9](https://github.com/Cap-go/capacitor-plus/compare/8.3.8...8.3.9) (2026-08-13)
 
 **Note:** Version bump only for package @capacitor-plus/ios

--- a/ios/package.json
+++ b/ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-plus/ios",
-  "version": "8.3.9",
+  "version": "8.3.10",
   "description": "Capacitor+: Enhanced Capacitor with automated upstream sync - Cross-platform apps with JavaScript and the web",
   "homepage": "https://capgo.app/docs/plugins/capacitor-plus/",
   "author": "Capgo Team <support@capgo.app> (https://capgo.app)",

--- a/lerna.json
+++ b/lerna.json
@@ -13,6 +13,6 @@
       "tagVersionPrefix": ""
     }
   },
-  "version": "8.3.9",
+  "version": "8.3.10",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

- Restores the lost `chore(release): 8.3.10` version bump onto `plus`, so the workspace `package.json` files, `lerna.json` and the changelogs match the `8.3.10` that is already tagged and published on npm.
- Adds a `concurrency` group to `.github/workflows/bump_version.yml` so only one "Bump version" run executes at a time per ref.

## Why

The release pipeline is currently wedged and will fail on every future push to `plus`.

`bump_version.yml` triggers on each push to `plus` with no concurrency guard. Merging the upstream-sync backlog produced several pushes in quick succession, so multiple runs started together, each computed the same next patch version, and each tried to create the same tag. One won; the rest died on:

```
fatal: tag '8.3.10' already exists
Process completed with exit code 128
```

The run that won pushed the tag but lost the race on the branch push, so `8.3.10` exists as a tag (commit `d260116`), as a GitHub release, and on npm as `latest` — but its version-bump commit never landed on `plus`. `plus` is still at `8.3.9`.

That leaves the pipeline stuck: every subsequent run computes `8.3.9 → 8.3.10` again and dies on the existing tag. No further release can go out until the branch is moved past `8.3.10`.

## How

- Cherry-picked commit `d260116` (`git cherry-pick -x`), preserving the original `github-actions[bot]` authorship. Its parent was `9cad499` (`chore(release): 8.3.9`), already an ancestor of `plus`, and nothing merged since touched the version files, so it applied cleanly.
- Added to `bump_version.yml`:

```yaml
concurrency:
  group: bump-version-${{ github.ref }}
  cancel-in-progress: false
```

Runs now queue instead of racing. `cancel-in-progress: false` is deliberate: a bump that has already tagged should be allowed to finish pushing.

The PR title starts with `chore(release):`, which matches the existing skip condition in `bump_version.yml`, so merging this will not kick off another release.

## Testing

- `bun run eslint` and `bun run prettier --check` pass locally on the branch.
- Verified `8.3.10` is genuinely published: `registry.npmjs.org/@capacitor-plus/core` reports `dist-tags.latest = 8.3.10`, so bumping `plus` to match is a correction rather than a version skip.
- Verified `git merge-base --is-ancestor d260116 origin/plus` returns false, confirming the commit really is missing from the branch.
- CI (setup / lint / test-cli / test-core / test-ios / test-android) runs on this PR.

## Not Tested

- The concurrency guard cannot be exercised until two pushes land close together again; it is a config change validated by reading, not by running.
- No npm publish was performed or verified from this branch.

---

Opened by an AI agent (Cursor) while working through the upstream-sync PR backlog.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2db0044b-6299-4fa0-9741-ce65b9e0c628?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2db0044b-6299-4fa0-9741-ce65b9e0c628&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-plus/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789178906&installation_model_id=430928&pr_number=105&repository=Cap-go%2Fcapacitor-plus&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-plus%2Fpull%2F105&signature=bc2db1b736fad455553f94e5192940378095545267fc43c2aa1d7ca3080c7401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-plus/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version 8.3.10 across the Capacitor, Android, iOS, core, and CLI packages.
  * This is a version-only release with no functional changes.

* **Documentation**
  * Added release notes and changelog entries for version 8.3.10 across supported packages.

* **Chores**
  * Improved version-release workflow handling so queued version updates can proceed reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->