### PR TITLE
fix(android): sync upstream SystemBars fixes #8480 and #8481

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -358,20 +358,22 @@ public class SystemBars extends Plugin {
         WindowInsetsControllerCompat windowInsetsControllerCompat = WindowCompat.getInsetsController(window, window.getDecorView());
 
         if (hide) {
-            if (bar.isEmpty() || bar.equals(BAR_STATUS_BAR)) {
+            if (bar.isEmpty()) {
+                windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.systemBars());
+            } else if (bar.equals(BAR_STATUS_BAR)) {
                 windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.statusBars());
-            }
-            if (bar.isEmpty() || bar.equals(BAR_GESTURE_BAR)) {
+            } else if (bar.equals(BAR_GESTURE_BAR)) {
                 windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.navigationBars());
                 navBarVisible = false;
             }
             return;
         }
 
-        if (bar.isEmpty() || bar.equals(BAR_STATUS_BAR)) {
+        if (bar.isEmpty()) {
             windowInsetsControllerCompat.show(WindowInsetsCompat.Type.systemBars());
-        }
-        if (bar.isEmpty() || bar.equals(BAR_GESTURE_BAR)) {
+        } else if (bar.equals(BAR_STATUS_BAR)) {
+            windowInsetsControllerCompat.show(WindowInsetsCompat.Type.statusBars());
+        } else if (bar.equals(BAR_GESTURE_BAR)) {
             windowInsetsControllerCompat.show(WindowInsetsCompat.Type.navigationBars());
             navBarVisible = true;
         }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -360,6 +360,7 @@ public class SystemBars extends Plugin {
         if (hide) {
             if (bar.isEmpty()) {
                 windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.systemBars());
+                navBarVisible = false;
             } else if (bar.equals(BAR_STATUS_BAR)) {
                 windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.statusBars());
             } else if (bar.equals(BAR_GESTURE_BAR)) {
@@ -371,6 +372,7 @@ public class SystemBars extends Plugin {
 
         if (bar.isEmpty()) {
             windowInsetsControllerCompat.show(WindowInsetsCompat.Type.systemBars());
+            navBarVisible = true;
         } else if (bar.equals(BAR_STATUS_BAR)) {
             windowInsetsControllerCompat.show(WindowInsetsCompat.Type.statusBars());
         } else if (bar.equals(BAR_GESTURE_BAR)) {

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -17,6 +17,7 @@ import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.webkit.WebViewCompat;
+import com.getcapacitor.Logger;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -33,6 +34,7 @@ public class SystemBars extends Plugin {
     static final String BAR_STATUS_BAR = "StatusBar";
     static final String BAR_GESTURE_BAR = "NavigationBar";
 
+    // TODO: In Cap 9, add an additional option "full"
     static final String INSETS_HANDLING_CSS = "css";
     static final String INSETS_HANDLING_DISABLE = "disable";
 
@@ -54,7 +56,7 @@ public class SystemBars extends Plugin {
         capacitorSystemBarsCheckMetaViewport();
         """;
 
-    private boolean insetHandlingEnabled = true;
+    private String insetsHandling = INSETS_HANDLING_CSS;
     private boolean hasViewportCover = false;
 
     private String currentStatusBarStyle = STYLE_DEFAULT;
@@ -81,7 +83,7 @@ public class SystemBars extends Plugin {
                     super.onPageCommitVisible(view, url);
                     View parentView = (View) getBridge().getWebView().getParent();
                     ViewCompat.requestApplyInsets(parentView);
-                    if (insetHandlingEnabled) {
+                    if (INSETS_HANDLING_CSS.equals(insetsHandling)) {
                         WindowInsetsCompat rootInsets = ViewCompat.getRootWindowInsets(parentView);
                         if (rootInsets != null) {
                             Insets safeArea = calcSafeAreaInsets(rootInsets);
@@ -105,9 +107,15 @@ public class SystemBars extends Plugin {
         String style = getConfig().getString("style", STYLE_DEFAULT).toUpperCase(Locale.US);
         boolean hidden = getConfig().getBoolean("hidden", false);
 
-        String insetsHandling = getConfig().getString("insetsHandling", "css");
-        if (insetsHandling.equals(INSETS_HANDLING_DISABLE)) {
-            insetHandlingEnabled = false;
+        String configuredInsetsHandling = getConfig().getString("insetsHandling", INSETS_HANDLING_CSS);
+        if (INSETS_HANDLING_CSS.equals(configuredInsetsHandling) || INSETS_HANDLING_DISABLE.equals(configuredInsetsHandling)) {
+            insetsHandling = configuredInsetsHandling;
+        } else {
+            Logger.warn(
+                "SystemBars",
+                "Unknown insetsHandling value '" + configuredInsetsHandling + "'. Falling back to '" + INSETS_HANDLING_CSS + "'."
+            );
+            insetsHandling = INSETS_HANDLING_CSS;
         }
 
         initWindowInsetsListener();
@@ -184,12 +192,14 @@ public class SystemBars extends Plugin {
 
     @JavascriptInterface
     public void onDOMReady() {
-        getActivity().runOnUiThread(() -> {
-            this.bridge.getWebView().evaluateJavascript(viewportMetaJSFunction, (res) -> {
-                hasViewportCover = res.equals("true");
-                ViewCompat.requestApplyInsets((View) getBridge().getWebView().getParent());
+        if (INSETS_HANDLING_CSS.equals(insetsHandling)) {
+            getActivity().runOnUiThread(() -> {
+                this.bridge.getWebView().evaluateJavascript(viewportMetaJSFunction, (res) -> {
+                    hasViewportCover = res.equals("true");
+                    ViewCompat.requestApplyInsets((View) getBridge().getWebView().getParent());
+                });
             });
-        });
+        }
     }
 
     private Insets calcSafeAreaInsets(WindowInsetsCompat insets) {
@@ -224,7 +234,7 @@ public class SystemBars extends Plugin {
     }
 
     private void initSafeAreaCSSVariables() {
-        if (insetHandlingEnabled) {
+        if (INSETS_HANDLING_CSS.equals(insetsHandling)) {
             View v = (View) this.getBridge().getWebView().getParent();
             WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(v);
             if (insets != null) {
@@ -235,6 +245,10 @@ public class SystemBars extends Plugin {
     }
 
     private void initWindowInsetsListener() {
+        if (INSETS_HANDLING_DISABLE.equals(insetsHandling)) {
+            return;
+        }
+
         ViewCompat.setOnApplyWindowInsetsListener((View) getBridge().getWebView().getParent(), (v, insets) -> {
             // getRootWindowInsets() bypasses AppCompat's intermediate view consuming the bottom inset on API < 30
             WindowInsetsCompat rawInsets = ViewCompat.getRootWindowInsets(v);
@@ -250,7 +264,7 @@ public class SystemBars extends Plugin {
                 // We need to correct for a possible shown IME
                 v.setPadding(0, 0, 0, keyboardVisible ? imeInsets.bottom : 0);
 
-                if (hasViewportCover && insetHandlingEnabled) {
+                if (hasViewportCover && INSETS_HANDLING_CSS.equals(insetsHandling)) {
                     Insets safeAreaInsets = calcSafeAreaInsets(safeAreaSource);
                     injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
                 }
@@ -277,7 +291,7 @@ public class SystemBars extends Plugin {
                 .setInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(), Insets.of(0, 0, 0, 0))
                 .build();
 
-            if (insetHandlingEnabled) {
+            if (INSETS_HANDLING_CSS.equals(insetsHandling)) {
                 Insets safeAreaInsets = calcSafeAreaInsets(safeAreaSource);
                 injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
             }

--- a/android/capacitor/src/test/java/com/getcapacitor/plugin/SystemBarsTest.java
+++ b/android/capacitor/src/test/java/com/getcapacitor/plugin/SystemBarsTest.java
@@ -1,0 +1,73 @@
+package com.getcapacitor.plugin;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.view.View;
+import android.view.Window;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
+import com.getcapacitor.Bridge;
+import java.lang.reflect.Method;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+public class SystemBarsTest {
+
+    @Test
+    public void showWithEmptyBarShowsSystemBars() throws Exception {
+        WindowInsetsControllerCompat controller = invokeSetHidden("");
+
+        verify(controller).show(WindowInsetsCompat.Type.systemBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.statusBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.navigationBars());
+    }
+
+    @Test
+    public void showWithStatusBarShowsOnlyStatusBars() throws Exception {
+        WindowInsetsControllerCompat controller = invokeSetHidden("StatusBar");
+
+        verify(controller).show(WindowInsetsCompat.Type.statusBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.systemBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.navigationBars());
+    }
+
+    @Test
+    public void showWithNavigationBarShowsOnlyNavigationBars() throws Exception {
+        WindowInsetsControllerCompat controller = invokeSetHidden("NavigationBar");
+
+        verify(controller).show(WindowInsetsCompat.Type.navigationBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.systemBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.statusBars());
+    }
+
+    private WindowInsetsControllerCompat invokeSetHidden(String bar) throws Exception {
+        SystemBars plugin = new SystemBars();
+        Bridge bridge = mock(Bridge.class);
+        AppCompatActivity activity = mock(AppCompatActivity.class);
+        Window window = mock(Window.class);
+        View decorView = mock(View.class);
+        WindowInsetsControllerCompat controller = mock(WindowInsetsControllerCompat.class);
+
+        when(bridge.getActivity()).thenReturn(activity);
+        when(activity.getWindow()).thenReturn(window);
+        when(window.getDecorView()).thenReturn(decorView);
+
+        plugin.setBridge(bridge);
+
+        try (MockedStatic<WindowCompat> windowCompat = mockStatic(WindowCompat.class)) {
+            windowCompat.when(() -> WindowCompat.getInsetsController(window, decorView)).thenReturn(controller);
+
+            Method setHidden = SystemBars.class.getDeclaredMethod("setHidden", boolean.class, String.class);
+            setHidden.setAccessible(true);
+            setHidden.invoke(plugin, false, bar);
+        }
+
+        return controller;
+    }
+}

--- a/android/capacitor/src/test/java/com/getcapacitor/plugin/SystemBarsTest.java
+++ b/android/capacitor/src/test/java/com/getcapacitor/plugin/SystemBarsTest.java
@@ -1,5 +1,7 @@
 package com.getcapacitor.plugin;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -13,6 +15,7 @@ import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 import com.getcapacitor.Bridge;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import org.junit.Test;
 import org.mockito.MockedStatic;
@@ -46,8 +49,66 @@ public class SystemBarsTest {
         verify(controller, never()).show(WindowInsetsCompat.Type.statusBars());
     }
 
-    private WindowInsetsControllerCompat invokeSetHidden(String bar) throws Exception {
+    @Test
+    public void hideWithEmptyBarHidesSystemBars() throws Exception {
+        WindowInsetsControllerCompat controller = invokeSetHidden(new SystemBars(), true, "");
+
+        verify(controller).hide(WindowInsetsCompat.Type.systemBars());
+        verify(controller, never()).hide(WindowInsetsCompat.Type.statusBars());
+        verify(controller, never()).hide(WindowInsetsCompat.Type.navigationBars());
+    }
+
+    @Test
+    public void hideWithStatusBarHidesOnlyStatusBars() throws Exception {
+        WindowInsetsControllerCompat controller = invokeSetHidden(new SystemBars(), true, "StatusBar");
+
+        verify(controller).hide(WindowInsetsCompat.Type.statusBars());
+        verify(controller, never()).hide(WindowInsetsCompat.Type.systemBars());
+        verify(controller, never()).hide(WindowInsetsCompat.Type.navigationBars());
+    }
+
+    @Test
+    public void togglingNavigationBarTracksNavBarVisible() throws Exception {
         SystemBars plugin = new SystemBars();
+
+        invokeSetHidden(plugin, true, "NavigationBar");
+        assertFalse(navBarVisible(plugin));
+
+        invokeSetHidden(plugin, false, "NavigationBar");
+        assertTrue(navBarVisible(plugin));
+    }
+
+    @Test
+    public void togglingAllBarsTracksNavBarVisible() throws Exception {
+        SystemBars plugin = new SystemBars();
+
+        invokeSetHidden(plugin, true, "");
+        assertFalse(navBarVisible(plugin));
+
+        invokeSetHidden(plugin, false, "");
+        assertTrue(navBarVisible(plugin));
+    }
+
+    @Test
+    public void hidingOnlyStatusBarLeavesNavBarVisible() throws Exception {
+        SystemBars plugin = new SystemBars();
+
+        invokeSetHidden(plugin, true, "StatusBar");
+
+        assertTrue(navBarVisible(plugin));
+    }
+
+    private boolean navBarVisible(SystemBars plugin) throws Exception {
+        Field field = SystemBars.class.getDeclaredField("navBarVisible");
+        field.setAccessible(true);
+        return field.getBoolean(plugin);
+    }
+
+    private WindowInsetsControllerCompat invokeSetHidden(String bar) throws Exception {
+        return invokeSetHidden(new SystemBars(), false, bar);
+    }
+
+    private WindowInsetsControllerCompat invokeSetHidden(SystemBars plugin, boolean hide, String bar) throws Exception {
         Bridge bridge = mock(Bridge.class);
         AppCompatActivity activity = mock(AppCompatActivity.class);
         Window window = mock(Window.class);
@@ -65,7 +126,7 @@ public class SystemBarsTest {
 
             Method setHidden = SystemBars.class.getDeclaredMethod("setHidden", boolean.class, String.class);
             setHidden.setAccessible(true);
-            setHidden.invoke(plugin, false, bar);
+            setHidden.invoke(plugin, hide, bar);
         }
 
         return controller;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Syncs two SystemBars fixes that are merged in `ionic-team/capacitor` but missing from `plus`:

- [#8481](https://github.com/ionic-team/capacitor/pull/8481) — respect `insetsHandling: "disable"`
- [#8480](https://github.com/ionic-team/capacitor/pull/8480) — show only the requested system bar

Plus one integration fix needed to make the two work together (details below).

## Why

Both were carried by the stale upstream-sync branches, bundled with the "upstream-preferred fallback" resolution that renamed `@capacitor-plus/*` back to `@capacitor/*` and wiped the fork's changelogs. Stripping that damage from #71/#83/#85/#87/#88 also dropped these two genuine fixes on the floor. CodeRabbit flagged both as out-of-diff findings while reviewing #67, which is how they resurfaced.

They are worth having on their own merits:

- **`insetsHandling: "disable"` did not work.** Upstream #8424 removed the `insetHandlingEnabled` guard, so the listener was installed and insets were rewritten regardless of config. #67 restored the guard on the CSS injections; #8481 finishes the job by returning early from `initWindowInsetsListener`, gating `onDOMReady`, and validating the config value with a warning on unknown input.
- **Hiding the status bar also showed the navigation bar.** `setHidden(false, "StatusBar")` called `show(Type.systemBars())`, which covers both bars. #8480 narrows each branch to the bar actually requested and adds `SystemBarsTest`.

## How

Cherry-picked `d4ad7ff` and `4c6c321` with `git cherry-pick -x`, preserving upstream authorship.

`d4ad7ff` conflicted with #67, which had just landed and reworks the same methods. Resolved by keeping #67's structure and layering #8481's config handling on top:

- `insetHandlingEnabled` (boolean) becomes `insetsHandling` (String), with all five call sites migrated to `INSETS_HANDLING_CSS.equals(insetsHandling)`.
- Kept #67's `ViewCompat.getRootWindowInsets(v)` in `initSafeAreaCSSVariables` rather than upstream's `WindowInsetsCompat.CONSUMED` fallback, which yields zeros below API 35.
- Kept #67's `ViewCompat.requestApplyInsets(parentView)` in `onDOMReady` over upstream's `getBridge().getWebView().requestApplyInsets()`.

The third commit is a fork-specific integration fix. `navBarVisible` (added by #67) was only updated in the per-bar branches, but #8480 restructured `setHidden` so `bar.isEmpty()` — the path `initSystemBars` uses for the `hidden` config — hides or shows every bar at once. With `hidden: true` the navigation bar was hidden while `navBarVisible` stayed `true`, so the API < 30 safe-area fallback reported a nav bar height for a bar that was not on screen. Upstream cannot have this bug because `navBarVisible` only exists here.

## Testing

- `bun run eslint` and `bun run prettier --check` pass locally.
- `SystemBarsTest.java` comes from upstream #8480 and runs in `test-android`.
- CI (setup / lint / test-cli / test-core / test-ios / test-android) runs on this PR.

## Not Tested

- No on-device verification of `insetsHandling: "disable"`, of hiding a single bar, or of the `navBarVisible` fix on an API < 30 device. All three are reasoned from the code and upstream's intent.

---

Opened by an AI agent (Cursor).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2db0044b-6299-4fa0-9741-ce65b9e0c628?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2db0044b-6299-4fa0-9741-ce65b9e0c628&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-plus/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789182015&installation_model_id=430928&pr_number=106&repository=Cap-go%2Fcapacitor-plus&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-plus%2Fpull%2F106&signature=5a25b30fd1e6a1c48c58fcb0e696af559d971f67d62fb5e3b9477b597a196346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-plus/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

