### PR TITLE
ci: install bun in release job so AI changelog generates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,10 @@ jobs:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
 
+      # Required by the `bun run changelog:ai` step below.
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Extract version from tag
         id: extract
         run: |
@@ -55,6 +59,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: bun run changelog:ai
+
       - name: Publish all packages to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Add `oven-sh/setup-bun@v2` to the tag publish job in `.github/workflows/build.yml`, so the existing `Generate AI changelog` step can actually run.

## Why
Every release from 8.3.5 to 8.3.12 shipped with the placeholder body:

```
_Changelog was not generated automatically for this release._
```

and a self-referential compare link (`compare/8.3.12...8.3.12`), because `steps.changelog.outputs.result`, `from_tag`, and `to_tag` were all empty.

The wiring other Cap-go plugin repos use (`id: changelog`, `continue-on-error: true`, Cloudflare secrets, `fetch-depth: 0`, and the `action-gh-release` body referencing `steps.changelog.outputs.*`) was already present here. The step itself failed. From the 8.3.12 run ([31664632096](https://github.com/Cap-go/capacitor-plus/actions/runs/31664632096)):

```
Run bun run changelog:ai
  CLOUDFLARE_API_TOKEN: ***
  CLOUDFLARE_ACCOUNT_ID: ***
/home/runner/work/_temp/….sh: line 1: bun: command not found
##[error]Process completed with exit code 127
```

The deploy job installs with npm and never set up bun, unlike `test.yml` and `sync-upstream.yml` which both use `oven-sh/setup-bun@v2`. Because the step is `continue-on-error: true`, the run stayed green and the release quietly fell back to the placeholder.

## How
One added step. Nothing else needed:

- `scripts/generate-ai-changelog.mjs` is byte-for-byte identical to the one in `Cap-go/capacitor-inappbrowser`, which produces real changelogs today, so the script, model, and Cloudflare response handling are fine.
- Both Cloudflare secrets are already present and non-empty (the run log masks each as `***`).
- Checkout already uses `fetch-depth: 0`, so `git describe` finds the previous tag.
- The `action-gh-release` body already consumes `steps.changelog.outputs.result` and builds the compare link from `from_tag`/`to_tag`.

Kept the plus-specific publish path untouched: npm workspace install, `npm run build --workspace=core|cli`, and the four-package `@capacitor-plus/*` publish loop. `bump_version.yml` and its lerna flow are unchanged, so package `CHANGELOG.md` files stay lerna-managed. `timeout-minutes: 10` is unchanged.

## Testing
Reproduced and verified the fix locally against real repo history at tag `8.3.12`:

- Confirmed the failure mode in CI logs: `bun: command not found`, exit 127, immediately before the release step emitted the placeholder body and the `8.3.12...8.3.12` link.
- Installed bun and ran `bun run changelog:ai`, which now resolves and executes the script (`Range: 8.3.11..8.3.12`), failing only at the Cloudflare call because this sandbox has no credentials.
- Stubbed the Cloudflare response and re-ran the script to confirm it writes all three outputs in valid `GITHUB_OUTPUT` form, including the heredoc-delimited multiline body:

```
result<<changelog_1786607743800
## Fixed
- Android inset regression on rotation
changelog_1786607743800
from_tag=8.3.11
to_tag=8.3.12
```

- Parsed the workflow YAML and confirmed step ordering (checkout → node → bun → install → build → changelog → publish → release) and `timeout-minutes: 10`.

## Not Tested
- A real tag push. The end-to-end result, including the live Cloudflare Workers AI call, can only be confirmed on the next release.
- `git diff --stat` under the `filter: blob:none` partial clone relies on lazy blob fetching. It works in `capacitor-inappbrowser` with the same checkout options and identical script, but it is untested in this repo's CI.

---

Authored by an AI agent (Cursor).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4388b6f0-e960-4ace-9c73-6d2bbfd3c3ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4388b6f0-e960-4ace-9c73-6d2bbfd3c3ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-plus/pr/107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789199793&installation_model_id=430928&pr_number=107&repository=Cap-go%2Fcapacitor-plus&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-plus%2Fpull%2F107&signature=2b8c81c19811a95b9368f361dd51432011bf22d7b6a9f84bf89ef7ef8a85928c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-plus/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployment workflow to prepare the required runtime before generating AI-assisted changelogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->