### PR TITLE
ci: use npm stage publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,9 @@ jobs:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Install npm CLI for staged publishing
+        run: npm install -g npm@^11.15.0
+
       # Required by the `bun run changelog:ai` step below.
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -60,7 +63,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: bun run changelog:ai
 
-      - name: Publish all packages to npm
+      - name: Stage all packages to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
@@ -74,14 +77,26 @@ jobs:
           fi
 
           echo "Publishing with tag: $NPM_TAG"
+          npm --version
 
           # Publish each package
           for pkg in core cli android ios; do
             echo "Publishing @capacitor-plus/$pkg@$VERSION"
             cd $pkg
-            npm publish --tag $NPM_TAG --provenance --access public
+            npm stage publish --tag $NPM_TAG --provenance --access public --ignore-scripts
             cd ..
           done
+
+      - name: Request stage approval
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.NPM_STAGE_DISPATCH_TOKEN }}
+        run: |
+          gh api --method POST repos/Cap-go/automations/dispatches \
+            -f event_type=npm-stage-approve \
+            -f "client_payload[repository]=${GITHUB_REPOSITORY}" \
+            -f "client_payload[run_id]=${GITHUB_RUN_ID}" \
+            -f "client_payload[package]=@capacitor-plus/core"
 
       - name: Create GitHub release
         id: create_release

--- a/.github/workflows/pr_beta_prompt.yml
+++ b/.github/workflows/pr_beta_prompt.yml
@@ -71,7 +71,6 @@ jobs:
                   '',
                   'The workflow will:',
                   '- publish a prerelease package on the `beta` tag',
-                  `- add a pinned \`pr-${pr.number}\` dist-tag for the selected package`,
                   '- update this comment with the install command',
                   '',
                   'Security note: beta publish is only enabled for branches inside this repository.',

--- a/.github/workflows/pr_beta_publish.yml
+++ b/.github/workflows/pr_beta_publish.yml
@@ -160,7 +160,7 @@ jobs:
               `Package: \`${packageSelector}\``,
               `Requested by @${actor}.`,
               '',
-              `This run will publish the PR head for the selected Capacitor Plus package to the \`beta\` npm tag and refresh \`pr-${prNumber}\`.`,
+              `This run will publish the PR head for the selected Capacitor Plus package to the \`beta\` npm tag.`,
               '',
               `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             ].join('\n');
@@ -203,6 +203,9 @@ jobs:
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Install npm CLI for staged publishing
+        run: npm install -g npm@^11.15.0
 
       - name: Install dependencies
         run: npm install
@@ -302,18 +305,25 @@ jobs:
           cd "$PACKAGE_DIR"
           npm run build
 
-      - name: Publish to npm beta
+      - name: Stage publish to npm beta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           PACKAGE_DIR: ${{ steps.package.outputs.package_dir }}
         run: |
           cd "$PACKAGE_DIR"
-          npm publish --tag beta --provenance --access public --ignore-scripts
+          npm --version
+          npm stage publish --tag beta --provenance --access public --ignore-scripts
 
-      - name: Add PR dist-tag
+      - name: Request stage approval
+        continue-on-error: true
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm dist-tag add "${{ steps.version.outputs.package_name }}@${{ steps.version.outputs.version }}" "pr-${{ steps.pr.outputs.pr_number }}"
+          GH_TOKEN: ${{ secrets.NPM_STAGE_DISPATCH_TOKEN }}
+        run: |
+          gh api --method POST repos/Cap-go/automations/dispatches \
+            -f event_type=npm-stage-approve \
+            -f "client_payload[repository]=${GITHUB_REPOSITORY}" \
+            -f "client_payload[run_id]=${GITHUB_RUN_ID}" \
+            -f "client_payload[package]=${{ steps.version.outputs.package_name }}"
 
       - name: Publish success comment
         if: ${{ success() }}
@@ -332,7 +342,7 @@ jobs:
               '',
               '## Beta npm build',
               '',
-              'Status: published',
+              'Status: staged',
               '',
               `Package: \`${packageDir}\` (${packageName})`,
               `Version: \`${version}\``,
@@ -342,11 +352,7 @@ jobs:
               'Latest beta:',
               '```sh',
               `npm install ${packageName}@beta`,
-              '```',
-              '',
-              'This PR only:',
-              '```sh',
-              `npm install ${packageName}@pr-${prNumber}`,
+              `npm install ${packageName}@${version}`,
               '```',
               '',
               `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,


### PR DESCRIPTION
## What
- Switch production and PR beta publishes from `npm publish` to `npm stage publish` for `@capacitor-plus/*`.

## Why
- npm no longer allows long-lived unattended publish tokens.

## How
- CI stages core/cli/android/ios with the org `NPM_TOKEN`.
- Drop the `pr-N` dist-tag from beta comments.

## Testing
- Workflow-only. Same stage flow as the Cap-go plugins.

## Not Tested
- A live tagged release or `/publish-beta` on this repo.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-plus/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789813010&installation_model_id=430928&pr_number=108&repository=Cap-go%2Fcapacitor-plus&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-plus%2Fpull%2F108&signature=6d0e92baa1ca4b3921c6467c25297661980bcd3776a575e63b3cc3407404ef49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-plus/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

