### PR TITLE
fix(ci): fetch upstream objects so plus branch sync works

### DIFF
--- a/.github/workflows/needs-reply.yml
+++ b/.github/workflows/needs-reply.yml
@@ -10,11 +10,26 @@ jobs:
     # Keep this job capped at 10 minutes; never raise it unless explicitly asked.
     timeout-minutes: 10
     steps:
+      - name: Check if issues are enabled
+        id: check-issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          HAS_ISSUES=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.has_issues')
+          echo "has_issues=${HAS_ISSUES}" >> "$GITHUB_OUTPUT"
+
+      - name: Skip when issues are disabled
+        if: steps.check-issues.outputs.has_issues != 'true'
+        run: echo "Issues are disabled on ${GITHUB_REPOSITORY}; skipping needs-reply workflow."
+
       - name: Setup Node.js
+        if: steps.check-issues.outputs.has_issues == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: 24.x
+
       - name: Close old issues that need reply
+        if: steps.check-issues.outputs.has_issues == 'true'
         uses: imhoffd/needs-reply@v2.0.0
         with:
           repo-token: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/needs-reply.yml
+++ b/.github/workflows/needs-reply.yml
@@ -15,7 +15,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          HAS_ISSUES=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.has_issues')
+          HAS_ISSUES=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.has_issues' 2>/dev/null || echo "false")
           echo "has_issues=${HAS_ISSUES}" >> "$GITHUB_OUTPUT"
 
       - name: Skip when issues are disabled

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -54,7 +54,6 @@ jobs:
           # or merge lazy-fetches ionic-team blobs from origin and fails with "not our ref"
           git config remote.upstream.promisor true
           git config remote.upstream.partialclonefilter blob:none
-          git fetch upstream main
           git fetch --no-filter upstream main
 
       - name: Check for new commits
@@ -105,15 +104,18 @@ jobs:
           else
             if [ -f .git/MERGE_HEAD ]; then
               echo "Merge conflict detected"
+              echo "merge_conflict=true" >> $GITHUB_OUTPUT
+              git merge --abort || git reset --hard origin/main
+              echo "merge_success=false" >> $GITHUB_OUTPUT
             else
               echo "Merge failed before MERGE_HEAD was created (missing git objects or other error)"
+              git merge --abort || true
+              exit 1
             fi
-            git merge --abort || true
-            echo "merge_success=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Create PR for conflicts
-        if: steps.regular-merge.outputs.merge_success == 'false'
+        if: steps.regular-merge.outputs.merge_conflict == 'true'
         env:
           GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |
@@ -194,7 +196,6 @@ jobs:
           # or merge lazy-fetches ionic-team blobs from origin and fails with "not our ref"
           git config remote.upstream.promisor true
           git config remote.upstream.partialclonefilter blob:none
-          git fetch upstream main
           git fetch --no-filter upstream main
 
       - name: Check for new commits
@@ -226,11 +227,14 @@ jobs:
           else
             if [ -f .git/MERGE_HEAD ]; then
               echo "Merge conflict detected"
+              echo "merge_conflict=true" >> $GITHUB_OUTPUT
+              git merge --abort || git reset --hard origin/plus
+              echo "merge_success=false" >> $GITHUB_OUTPUT
             else
               echo "Merge failed before MERGE_HEAD was created (missing git objects or other error)"
+              git merge --abort || true
+              exit 1
             fi
-            git merge --abort || true
-            echo "merge_success=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Push if merge succeeded
@@ -240,7 +244,7 @@ jobs:
           echo "Successfully pushed upstream changes to plus branch"
 
       - name: Create PR for conflicts
-        if: steps.merge.outputs.merge_success == 'false'
+        if: steps.merge.outputs.merge_conflict == 'true'
         env:
           GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -50,7 +50,12 @@ jobs:
       - name: Add upstream and fetch
         run: |
           git remote add upstream https://github.com/${{ env.UPSTREAM_REPO }}.git || true
+          # checkout uses filter:blob:none, so origin is the promisor remote; upstream must be too
+          # or merge lazy-fetches ionic-team blobs from origin and fails with "not our ref"
+          git config remote.upstream.promisor true
+          git config remote.upstream.partialclonefilter blob:none
           git fetch upstream main
+          git fetch --no-filter upstream main
 
       - name: Check for new commits
         id: check-commits
@@ -98,8 +103,12 @@ jobs:
             git push origin main
             echo "merge_success=true" >> $GITHUB_OUTPUT
           else
-            echo "Merge conflict detected"
-            git merge --abort
+            if [ -f .git/MERGE_HEAD ]; then
+              echo "Merge conflict detected"
+            else
+              echo "Merge failed before MERGE_HEAD was created (missing git objects or other error)"
+            fi
+            git merge --abort || true
             echo "merge_success=false" >> $GITHUB_OUTPUT
           fi
 
@@ -181,7 +190,12 @@ jobs:
       - name: Add upstream and fetch
         run: |
           git remote add upstream https://github.com/${{ env.UPSTREAM_REPO }}.git || true
+          # checkout uses filter:blob:none, so origin is the promisor remote; upstream must be too
+          # or merge lazy-fetches ionic-team blobs from origin and fails with "not our ref"
+          git config remote.upstream.promisor true
+          git config remote.upstream.partialclonefilter blob:none
           git fetch upstream main
+          git fetch --no-filter upstream main
 
       - name: Check for new commits
         id: check-commits
@@ -210,8 +224,12 @@ jobs:
             echo "Merge successful!"
             echo "merge_success=true" >> $GITHUB_OUTPUT
           else
-            echo "Merge conflict detected"
-            git merge --abort
+            if [ -f .git/MERGE_HEAD ]; then
+              echo "Merge conflict detected"
+            else
+              echo "Merge failed before MERGE_HEAD was created (missing git objects or other error)"
+            fi
+            git merge --abort || true
             echo "merge_success=false" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Fix `sync-branches.yml` so merges with `ionic-team/capacitor` work under `actions/checkout` partial clones (`filter: blob:none`).
- Harden merge failure handling so the workflow can open conflict PRs instead of exiting 128.
- Make `needs-reply.yml` a no-op success when GitHub issues are disabled on this repo.

## Why
The scheduled `sync-plus-branch` job has failed daily since partial-clone checkout was introduced. Latest failure: [actions run 32334591459](https://github.com/Cap-go/capacitor-plus/actions/runs/32334591459).

**Root cause (verified in logs):**
1. `actions/checkout@v6` with `filter: blob:none` makes `origin` (Cap-go/capacitor-plus) the promisor remote.
2. The job fetches `upstream/main` but does not register `upstream` as a promisor remote.
3. `git merge upstream/main` lazy-fetches missing blobs from `origin`, which does not have Ionic objects → `upload-pack: not our ref` / `could not fetch … from promisor remote`.
4. Merge never starts (`MERGE_HEAD` missing), but the step prints "Merge conflict detected" for any non-zero merge exit.
5. `git merge --abort` then fails with exit 128 under `bash -e`, so `merge_success=false` is never written and the "Create PR for conflicts" step is skipped.

`sync-main-branch` currently succeeds only because there are no pending upstream commits; it uses the same pattern and would hit the same bug once upstream moves ahead.

## How
### `sync-branches.yml` (both `sync-main-branch` and `sync-plus-branch`)
- After adding `upstream`, configure it as a promisor remote with the same blob filter as checkout.
- Run `git fetch --no-filter upstream main` to prefetch merge objects from Ionic before merging.
- On merge failure: distinguish conflict vs pre-merge failure in logs, use `git merge --abort || true`, and always write `merge_success=false` so conflict PR creation can run.

### `needs-reply.yml`
- Query `repos/{owner}/{repo}.has_issues` via `gh api`.
- Skip the `imhoffd/needs-reply` action when issues are disabled (currently `false` on Cap-go/capacitor-plus). The scheduled job exits green instead of failing on missing/disabled issue APIs.

## Testing
- Reproduced the CI failure signature from [run 32334591459](https://github.com/Cap-go/capacitor-plus/actions/runs/32334591459) logs.
- Locally simulated partial clones (`filter:blob:none` + origin promisor) and confirmed merge reaches normal conflict resolution with upstream promisor config + `--no-filter` fetch (no promisor fatal).
- Confirmed `plus` is **30 commits behind** `ionic-team/capacitor` `main` (merge-base `b3c769e8`).

## Not Tested
- Full GitHub Actions run after merge (please re-run **Sync Branches from Upstream** → `plus` via `workflow_dispatch` once this PR is merged).

## `plus` catch-up (follow-up — not in this PR)
A local merge of `upstream/main` into `plus` is **not clean**: conflicts in Capgo overlays and upstream churn, including:
- `.github/workflows/ci.yml` (deleted on plus, modified upstream)
- `CHANGELOG.md` files and `lerna.json` / package versions
- `android/.../SystemBars.java`, `SystemBarsTest.java`, `BridgeWebChromeClient.java`
- `android|cli|core|ios/package.json`

This PR fixes the automation only. After merge, the workflow should either push a clean merge or open a conflict-resolution PR.

**Existing open sync PRs left untouched:**
- #81 — upstream PR #8521 (`sync/upstream-pr-8521`)
- #82 — upstream PR #8524 (`sync/upstream-pr-8524`)

## How to verify after merge
1. Actions → **Sync Branches from Upstream** → Run workflow → branch: `plus`.
2. Expect `sync-plus-branch` to pass **or** open/update a conflict sync PR (not exit 128 on promisor errors).
3. Confirm `needs-reply.yml` scheduled run succeeds with "Issues are disabled … skipping".

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-621e5900-fff9-46ed-8ec1-46edc2626b17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-621e5900-fff9-46ed-8ec1-46edc2626b17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-plus/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789833722&installation_model_id=430928&pr_number=109&repository=Cap-go%2Fcapacitor-plus&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-plus%2Fpull%2F109&signature=1bf5d1e1333d3bdc6932e70429e6457aa95fdb742ecebadc14a958194d55f802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-plus/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow behavior when issue tracking is disabled by skipping unnecessary issue-processing steps.
  * Enhanced branch synchronization reliability, including safer handling of fetches, merge conflicts, and merge cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->