### PR TITLE
fix(ci): resolve modify/delete conflicts in sync conflict PRs

### DIFF
--- a/.github/scripts/sync-gh-helpers.sh
+++ b/.github/scripts/sync-gh-helpers.sh
@@ -125,3 +125,41 @@ create_or_update_conflict_issue() {
     --json number \
     -q '.[0].number'
 }
+
+merge_upstream_preferred() {
+  local commit_message="$1"
+
+  if git merge upstream/main -X theirs --no-edit -m "$commit_message"; then
+    return 0
+  fi
+
+  local unmerged
+  unmerged=$(git diff --name-only --diff-filter=U)
+  if [ -z "$unmerged" ]; then
+    return 1
+  fi
+
+  local file
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    # -X theirs does not resolve modify/delete conflicts; prefer upstream version.
+    if git checkout --theirs -- "$file" 2>/dev/null; then
+      git add "$file"
+    elif git rm -f "$file" 2>/dev/null; then
+      :
+    else
+      return 1
+    fi
+  done <<< "$unmerged"
+
+  if [ -n "$(git diff --name-only --diff-filter=U)" ]; then
+    return 1
+  fi
+
+  if [ -f .git/MERGE_HEAD ]; then
+    git commit --no-edit || git commit -m "$commit_message"
+    return 0
+  fi
+
+  return 1
+}

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -55,6 +55,7 @@ jobs:
           git config remote.upstream.promisor true
           git config remote.upstream.partialclonefilter blob:none
           git fetch --no-filter upstream main
+          git fetch --refetch --no-filter upstream main
 
       - name: Check for new commits
         id: check-commits
@@ -132,8 +133,8 @@ jobs:
           SYNC_BRANCH="sync/main-upstream-$(date +%Y%m%d-%H%M%S)"
           git checkout -b "$SYNC_BRANCH" origin/main
 
-          if ! git merge upstream/main -X theirs --no-edit -m "chore: sync main with upstream (upstream-preferred conflicts)"; then
-            git merge --abort || true
+          if ! merge_upstream_preferred "chore: sync main with upstream (upstream-preferred conflicts)"; then
+            git merge --abort || git reset --hard origin/main
             echo "Unable to resolve merge conflicts with the upstream-preferred strategy. Manual resolution is required."
             create_or_update_conflict_issue "${GITHUB_REPOSITORY}" \
               "⚠️ Upstream sync requires manual conflict resolution" \
@@ -197,6 +198,7 @@ jobs:
           git config remote.upstream.promisor true
           git config remote.upstream.partialclonefilter blob:none
           git fetch --no-filter upstream main
+          git fetch --refetch --no-filter upstream main
 
       - name: Check for new commits
         id: check-commits
@@ -259,10 +261,10 @@ jobs:
           fi
 
           SYNC_BRANCH="sync/plus-upstream-$(date +%Y%m%d-%H%M%S)"
-          git checkout -b "$SYNC_BRANCH" plus
+          git checkout -b "$SYNC_BRANCH" origin/plus
 
-          if ! git merge upstream/main -X theirs --no-edit -m "chore: sync plus with upstream main (upstream-preferred conflicts)"; then
-            git merge --abort || true
+          if ! merge_upstream_preferred "chore: sync plus with upstream main (upstream-preferred conflicts)"; then
+            git merge --abort || git reset --hard origin/plus
             echo "Unable to resolve merge conflicts with the upstream-preferred strategy. Manual resolution is required."
             create_or_update_conflict_issue "${GITHUB_REPOSITORY}" \
               "⚠️ Upstream sync requires manual conflict resolution" \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Fix `Create PR for conflicts` in `sync-branches.yml` when upstream sync hits modify/delete conflicts (e.g. `.github/workflows/ci.yml` deleted on `plus`, modified upstream).
- Refetch upstream objects before merge to reduce promisor lazy-fetch errors during merge.

## Why
[Run 32394290222](https://github.com/Cap-go/capacitor-plus/actions/runs/32394290222/job/96507414329) shows PR #109 fixed the promisor crash and correctly detected merge conflicts, but the job still failed at **Create PR for conflicts**:
- `git merge upstream/main -X theirs` auto-resolved content conflicts
- **modify/delete** on `.github/workflows/ci.yml` stayed unmerged
- Step exited 1 → no conflict PR created

## How
- Added `merge_upstream_preferred()` in `.github/scripts/sync-gh-helpers.sh`: runs `-X theirs`, then for remaining unmerged paths runs `git checkout --theirs` + `git add` (covers modify/delete), then commits.
- Both `sync-main-branch` and `sync-plus-branch` conflict PR steps use the helper.
- Added `git fetch --refetch --no-filter upstream main` after initial upstream fetch.
- Conflict PR branches now checkout from `origin/plus` / `origin/main`.

## Testing
- Reproduced failure signature from run 32394290222 logs.
- Locally simulated partial clone + upstream merge; helper completes merge when only modify/delete conflict remains on `ci.yml`.

## Not Tested
- Full GitHub Actions re-run after merge (please re-run **Sync Branches from Upstream** → `plus`).

## Notes
- Open sync PRs **#81** and **#82** left untouched.
- Conflict PR may re-introduce upstream `.github/workflows/ci.yml`; review before merging sync PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-621e5900-fff9-46ed-8ec1-46edc2626b17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-621e5900-fff9-46ed-8ec1-46edc2626b17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-plus/pr/110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789837273&installation_model_id=430928&pr_number=110&repository=Cap-go%2Fcapacitor-plus&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-plus%2Fpull%2F110&signature=e26c605ae80788f94a1228bca0981d9b7ee978c1e727449ca89dd98fedfd1a80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-plus/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated branch synchronization by preferring upstream changes during merges.
  * Added handling for unresolved conflicts, including selecting or removing upstream files where appropriate.
  * Ensured failed conflict resolution restores the affected branch to a clean state.
* **Maintenance**
  * Improved upstream refetching to ensure complete branch data is available during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->